### PR TITLE
Add charts page: weekly mileage, ATL/CTL, and aerobic efficiency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "rich>=13.0",
     "fastapi>=0.100",
     "uvicorn>=0.20",
+    "matplotlib>=3.7",
 ]
 
 [project.scripts]

--- a/strides_ai/charts_data.py
+++ b/strides_ai/charts_data.py
@@ -1,0 +1,180 @@
+"""Chart data computation: weekly mileage, ATL/CTL, and pace trends."""
+
+import math
+from collections import defaultdict
+from datetime import date, timedelta
+
+M_TO_MI = 0.000621371
+M_TO_KM = 0.001
+
+
+def _dist(distance_m: float, unit: str) -> float:
+    return (distance_m or 0.0) * (M_TO_MI if unit == "miles" else M_TO_KM)
+
+
+def _pace(avg_pace_s_per_km: float, unit: str) -> float:
+    """Convert s/km → s/unit."""
+    return avg_pace_s_per_km * (1.60934 if unit == "miles" else 1.0)
+
+
+# ── Weekly mileage ────────────────────────────────────────────────────────────
+
+def compute_weekly_mileage(activities: list[dict], unit: str) -> list[dict]:
+    """Weekly totals (Mon–Sun) with 4-week trailing rolling average."""
+    weekly: dict[date, float] = defaultdict(float)
+    for act in activities:
+        d = date.fromisoformat(act["date"])
+        week_start = d - timedelta(days=d.weekday())  # Monday
+        weekly[week_start] += _dist(act["distance_m"], unit)
+
+    if not weekly:
+        return []
+
+    today = date.today()
+    current_week = today - timedelta(days=today.weekday())
+
+    # Fill every week from first run to current (including zero weeks)
+    weeks: list[date] = []
+    w = min(weekly)
+    while w <= current_week:
+        weeks.append(w)
+        w += timedelta(weeks=1)
+
+    result = []
+    for i, w in enumerate(weeks):
+        dist = weekly.get(w, 0.0)
+        window = [weekly.get(weeks[j], 0.0) for j in range(max(0, i - 3), i + 1)]
+        result.append({
+            "week": w.isoformat(),
+            "distance": round(dist, 2),
+            "rolling_avg": round(sum(window) / len(window), 2),
+            "is_current": w == current_week,
+        })
+    return result
+
+
+# ── ATL / CTL ─────────────────────────────────────────────────────────────────
+
+def compute_atl_ctl(activities: list[dict], unit: str) -> list[dict]:
+    """Daily ATL (7-day EWA), CTL (42-day EWA), and their ratio."""
+    if not activities:
+        return []
+
+    daily: dict[date, float] = defaultdict(float)
+    for act in activities:
+        daily[date.fromisoformat(act["date"])] += _dist(act["distance_m"], unit)
+
+    alpha_atl = 1 - math.exp(-1 / 7)
+    alpha_ctl = 1 - math.exp(-1 / 42)
+    atl = ctl = 0.0
+
+    result = []
+    cur = min(daily)
+    today = date.today()
+    while cur <= today:
+        load = daily.get(cur, 0.0)
+        atl += alpha_atl * (load - atl)
+        ctl += alpha_ctl * (load - ctl)
+        ratio = round(atl / ctl, 3) if ctl > 1e-3 else None
+        result.append({
+            "date": cur.isoformat(),
+            "atl": round(atl, 3),
+            "ctl": round(ctl, 3),
+            "ratio": ratio,
+        })
+        cur += timedelta(days=1)
+    return result
+
+
+# ── Aerobic efficiency ────────────────────────────────────────────────────────
+
+MIN_QUALIFYING = 10
+HR_LOW, HR_HIGH = 120, 155
+
+
+def compute_aerobic_efficiency(activities: list[dict], unit: str) -> dict:
+    """Aerobic efficiency = speed (unit/hr) / avg_HR × 100 for easy-effort runs.
+
+    Filters to runs with avg HR between 120–155 bpm to exclude warm-ups,
+    races, and HR sensor dropouts.  Higher value → fitter.
+    """
+    qualifying = []
+    for act in activities:
+        hr = act.get("avg_hr")
+        if not hr or not (HR_LOW <= hr <= HR_HIGH):
+            continue
+        if not act.get("avg_pace_s_per_km"):
+            continue
+        pace_s = _pace(act["avg_pace_s_per_km"], unit)  # s/unit
+        if pace_s <= 0:
+            continue
+        # efficiency: how fast per HR unit (higher = better)
+        eff = (3600.0 / pace_s) / hr * 100.0
+        qualifying.append({
+            "date": act["date"],
+            "efficiency": round(eff, 3),
+            "name": act.get("name") or "",
+            "hr": round(hr, 1),
+            "pace_s": round(pace_s),
+        })
+
+    qualifying.sort(key=lambda x: x["date"])
+    n = len(qualifying)
+
+    if n < MIN_QUALIFYING:
+        return {
+            "has_enough_data": False,
+            "qualifying_count": n,
+            "scatter": qualifying,
+            "rolling_avg": [],
+            "improving": False,
+        }
+
+    # 4-week (28-day) rolling average at each qualifying run's date
+    rolling_avg = []
+    for pt in qualifying:
+        d = date.fromisoformat(pt["date"])
+        window_start = d - timedelta(days=27)
+        window = [
+            q["efficiency"] for q in qualifying
+            if window_start <= date.fromisoformat(q["date"]) <= d
+        ]
+        rolling_avg.append({
+            "date": pt["date"],
+            "avg": round(sum(window) / len(window), 3),
+        })
+
+    # Improving: last 4 weeks avg vs previous 4 weeks avg
+    today = date.today()
+    last_4wk = [
+        q["efficiency"] for q in qualifying
+        if date.fromisoformat(q["date"]) >= today - timedelta(days=28)
+    ]
+    prev_4wk = [
+        q["efficiency"] for q in qualifying
+        if today - timedelta(days=56) <= date.fromisoformat(q["date"]) < today - timedelta(days=28)
+    ]
+    improving = (
+        len(last_4wk) >= 2 and len(prev_4wk) >= 2
+        and (sum(last_4wk) / len(last_4wk)) > (sum(prev_4wk) / len(prev_4wk))
+    )
+
+    return {
+        "has_enough_data": True,
+        "qualifying_count": n,
+        "scatter": qualifying,
+        "rolling_avg": rolling_avg,
+        "improving": improving,
+    }
+
+
+# ── Combined ──────────────────────────────────────────────────────────────────
+
+def get_chart_data(activities, unit: str = "miles") -> dict:
+    acts = [dict(a) for a in activities]
+    return {
+        "unit": unit,
+        "weekly_mileage": compute_weekly_mileage(acts, unit),
+        "atl_ctl": compute_atl_ctl(acts, unit),
+        "aerobic_efficiency": compute_aerobic_efficiency(acts, unit),
+    }

--- a/strides_ai/cli.py
+++ b/strides_ai/cli.py
@@ -1,9 +1,10 @@
-"""Entry point: auth → sync → chat."""
+"""Entry point: auth → sync → chat, plus `charts` subcommand."""
 
 import argparse
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -50,10 +51,254 @@ def _open_editor(path) -> None:
         print(f"Could not find an editor. Open this file manually:\n  {path}")
 
 
+# ── charts subcommand ─────────────────────────────────────────────────────────
+
+def _run_charts(unit: str, output: str | None) -> None:
+    try:
+        import matplotlib
+        import matplotlib.pyplot as plt
+        import matplotlib.dates as mdates
+    except ImportError:
+        print("matplotlib is required for charts: pip install matplotlib")
+        sys.exit(1)
+
+    from .charts_data import get_chart_data
+
+    init_db()
+    activities = get_all_activities()
+    if not activities:
+        print("No activities found. Run 'strides-ai' to sync your Strava data first.")
+        return
+
+    data = get_chart_data(activities, unit)
+    ul = "mi" if unit == "miles" else "km"
+
+    fig, axes = plt.subplots(3, 1, figsize=(14, 16))
+    fig.patch.set_facecolor("#111827")
+    fig.suptitle("Training Dashboard", fontsize=16, fontweight="bold", color="#f3f4f6")
+
+    _plot_weekly_mileage(axes[0], data["weekly_mileage"], ul, fig)
+    _plot_atl_ctl(axes[1], data["atl_ctl"], ul, fig)
+    _plot_pace_scatter(axes[2], data["pace_scatter"], data["pace_trends"], unit, ul, fig)
+
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
+
+    out_path = Path(output) if output else Path.home() / ".strides_ai" / "charts.png"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=150, bbox_inches="tight", facecolor=fig.get_facecolor())
+    print(f"Saved: {out_path}")
+
+    try:
+        plt.show()
+    except Exception:
+        pass  # headless / no display
+
+
+def _style_ax(ax):
+    """Apply dark-theme styling to a matplotlib axes."""
+    ax.set_facecolor("#1f2937")
+    ax.tick_params(colors="#9ca3af", labelsize=9)
+    ax.xaxis.label.set_color("#9ca3af")
+    ax.yaxis.label.set_color("#9ca3af")
+    ax.title.set_color("#f3f4f6")
+    for spine in ax.spines.values():
+        spine.set_edgecolor("#374151")
+    ax.grid(axis="y", color="#374151", linewidth=0.6, linestyle="--")
+
+
+def _plot_weekly_mileage(ax, weeks: list[dict], ul: str, fig) -> None:
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    from datetime import date
+
+    if not weeks:
+        ax.text(0.5, 0.5, "No data", transform=ax.transAxes, ha="center", color="#6b7280")
+        return
+
+    # Show last 52 weeks for readability
+    weeks = weeks[-52:]
+    dates = [date.fromisoformat(w["week"]) for w in weeks]
+    dists = [w["distance"] for w in weeks]
+    rollavg = [w["rolling_avg"] for w in weeks]
+    colors = ["#4ade80" if w["is_current"] else "#22d3ee" for w in weeks]
+
+    ax.bar(dates, dists, color=colors, width=5, alpha=0.85, label=f"Weekly distance ({ul})")
+    ax.plot(dates, rollavg, color="#fb923c", linewidth=2, linestyle="--",
+            marker="o", markersize=3, label="4-week avg")
+
+    ax.set_title(f"Weekly {ul.upper() if ul == 'km' else 'Mileage'}")
+    ax.set_ylabel(f"Distance ({ul})")
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b '%y"))
+    ax.xaxis.set_major_locator(mdates.MonthLocator(interval=2))
+    plt.setp(ax.xaxis.get_majorticklabels(), rotation=35, ha="right")
+    ax.legend(facecolor="#1f2937", edgecolor="#374151", labelcolor="#d1d5db", fontsize=9)
+    _style_ax(ax)
+
+    # Legend color patch for current week
+    from matplotlib.patches import Patch
+    handles, labels = ax.get_legend_handles_labels()
+    handles.append(Patch(color="#4ade80", alpha=0.85, label="Current week"))
+    ax.legend(handles=handles, facecolor="#1f2937", edgecolor="#374151",
+              labelcolor="#d1d5db", fontsize=9)
+
+
+def _plot_atl_ctl(ax, atl_ctl: list[dict], ul: str, fig) -> None:
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    import math
+    from datetime import date
+
+    if not atl_ctl:
+        ax.text(0.5, 0.5, "No data", transform=ax.transAxes, ha="center", color="#6b7280")
+        return
+
+    # Show last 365 days
+    atl_ctl = atl_ctl[-365:]
+    dates2 = [date.fromisoformat(d["date"]) for d in atl_ctl]
+    atl_vals = [d["atl"] for d in atl_ctl]
+    ctl_vals = [d["ctl"] for d in atl_ctl]
+    ratio_vals = [d["ratio"] if d["ratio"] is not None else float("nan") for d in atl_ctl]
+
+    ax_ratio = ax.twinx()
+
+    ax.plot(dates2, atl_vals, color="#ef4444", linewidth=1.5, label=f"ATL 7d ({ul}/day)")
+    ax.plot(dates2, ctl_vals, color="#60a5fa", linewidth=1.5, label=f"CTL 42d ({ul}/day)")
+    ax.set_ylabel(f"Load ({ul}/day)")
+
+    ax_ratio.plot(dates2, ratio_vals, color="#a78bfa", linewidth=1.5,
+                  linestyle="--", label="ATL/CTL ratio")
+    ax_ratio.axhspan(0.8, 1.3, alpha=0.08, color="#22c55e")
+    ax_ratio.axhspan(1.3, 2.5, alpha=0.08, color="#ef4444")
+    ax_ratio.axhspan(0.0, 0.8, alpha=0.08, color="#6b7280")
+    ax_ratio.axhline(0.8, color="#6b7280", linewidth=0.6, linestyle=":")
+    ax_ratio.axhline(1.3, color="#ef4444", linewidth=0.6, linestyle=":")
+    ax_ratio.set_ylim(0, 2.5)
+    ax_ratio.set_ylabel("ATL/CTL ratio", color="#a78bfa")
+    ax_ratio.tick_params(colors="#9ca3af", labelsize=9)
+    ax_ratio.yaxis.label.set_color("#a78bfa")
+    for spine in ax_ratio.spines.values():
+        spine.set_edgecolor("#374151")
+
+    ax.set_title("Training Load (ATL / CTL)")
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b '%y"))
+    ax.xaxis.set_major_locator(mdates.MonthLocator(interval=2))
+    plt.setp(ax.xaxis.get_majorticklabels(), rotation=35, ha="right")
+
+    lines1, labels1 = ax.get_legend_handles_labels()
+    lines2, labels2 = ax_ratio.get_legend_handles_labels()
+    ax.legend(lines1 + lines2, labels1 + labels2, loc="upper left",
+              facecolor="#1f2937", edgecolor="#374151", labelcolor="#d1d5db", fontsize=9)
+    _style_ax(ax)
+
+    # Hover annotation
+    annot = ax_ratio.annotate(
+        "", xy=(0, 0), xytext=(15, 15), textcoords="offset points",
+        bbox=dict(boxstyle="round,pad=0.4", fc="#1f2937", ec="#374151", alpha=0.95),
+        arrowprops=dict(arrowstyle="->", color="#6b7280"),
+        color="#f3f4f6", fontsize=8,
+    )
+    annot.set_visible(False)
+
+    def on_hover(event):
+        if event.inaxes not in (ax, ax_ratio):
+            if annot.get_visible():
+                annot.set_visible(False)
+                fig.canvas.draw_idle()
+            return
+        if not dates2:
+            return
+        try:
+            hover_date = mdates.num2date(event.xdata).date()
+            idx = min(range(len(dates2)), key=lambda i: abs((dates2[i] - hover_date).days))
+            d = atl_ctl[idx]
+            r = ratio_vals[idx]
+            r_str = f"{r:.2f}" if not math.isnan(r) else "N/A"
+            if not math.isnan(r):
+                zone = ("⚠ Injury risk" if r > 1.3 else "↓ Detraining" if r < 0.8 else "✓ Optimal")
+            else:
+                zone = ""
+            annot.xy = (mdates.date2num(dates2[idx]), r if not math.isnan(r) else 0)
+            annot.set_text(
+                f"{d['date']}\nATL: {d['atl']:.2f}  CTL: {d['ctl']:.2f}\nRatio: {r_str}  {zone}"
+            )
+            annot.set_visible(True)
+            fig.canvas.draw_idle()
+        except Exception:
+            pass
+
+    fig.canvas.mpl_connect("motion_notify_event", on_hover)
+
+
+def _plot_pace_scatter(ax, scatter: dict, trends: dict, unit: str, ul: str, fig) -> None:
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    from datetime import date
+
+    short_thresh = 3 if unit == "miles" else 5
+    med_thresh = 6 if unit == "miles" else 10
+
+    bucket_cfg = [
+        ("long",   f"Long (≥{med_thresh} {ul})",                     "#6366f1"),
+        ("medium", f"Medium ({short_thresh}–{med_thresh} {ul})",      "#10b981"),
+        ("short",  f"Short (<{short_thresh} {ul})",                   "#f59e0b"),
+    ]
+
+    def fmt_pace(s, _):
+        return f"{int(s)//60}:{int(s)%60:02d}"
+
+    any_data = False
+    for bucket, label, color in bucket_cfg:
+        pts = scatter.get(bucket, [])
+        if not pts:
+            continue
+        any_data = True
+        dates_b = [date.fromisoformat(p["date"]) for p in pts]
+        paces = [p["pace_s"] for p in pts]
+        ax.scatter(dates_b, paces, color=color, alpha=0.65, s=18, label=label)
+
+        tr = trends.get(bucket, [])
+        if len(tr) == 2:
+            t_dates = [date.fromisoformat(t["date"]) for t in tr]
+            t_paces = [t["pace_s"] for t in tr]
+            ax.plot(t_dates, t_paces, color=color, linewidth=2.0, alpha=0.85)
+
+    if not any_data:
+        ax.text(0.5, 0.5, "No data with pace", transform=ax.transAxes,
+                ha="center", color="#6b7280")
+        _style_ax(ax)
+        return
+
+    ax.yaxis.set_major_formatter(plt.FuncFormatter(fmt_pace))
+    ax.invert_yaxis()  # faster (lower seconds) at top
+    ax.set_title(f"Pace Trend by Distance (min/{ul})")
+    ax.set_ylabel(f"Pace (min/{ul})")
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b '%y"))
+    ax.xaxis.set_major_locator(mdates.MonthLocator(interval=2))
+    plt.setp(ax.xaxis.get_majorticklabels(), rotation=35, ha="right")
+    ax.legend(facecolor="#1f2937", edgecolor="#374151", labelcolor="#d1d5db", fontsize=9)
+    _style_ax(ax)
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
 def main() -> None:
     load_dotenv()
 
     parser = argparse.ArgumentParser(prog="strides-ai")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # charts subcommand
+    charts_p = subparsers.add_parser("charts", help="Generate training charts")
+    charts_p.add_argument(
+        "--unit", choices=["miles", "km"], default="miles",
+        help="Distance unit (default: miles)",
+    )
+    charts_p.add_argument(
+        "--output", metavar="FILE",
+        help="Save PNG to FILE (default: ~/.strides_ai/charts.png)",
+    )
+
+    # Top-level flags for the default chat mode
     parser.add_argument(
         "--setup-profile",
         action="store_true",
@@ -61,10 +306,14 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # DB schema (needed even for --setup-profile so the dir exists)
+    # ── charts ────────────────────────────────────────────────────────────────
+    if args.command == "charts":
+        _run_charts(args.unit, args.output)
+        return
+
+    # ── chat (default) ────────────────────────────────────────────────────────
     init_db()
 
-    # ── Profile handling ──────────────────────────────────────────────────────
     newly_created = ensure_profile_file()
 
     if args.setup_profile or newly_created:
@@ -77,7 +326,6 @@ def main() -> None:
         if args.setup_profile:
             print("Profile saved. Run strides-ai to start coaching.")
             return
-        # After a first-run edit, continue into the app
 
     client_id = os.environ.get("STRAVA_CLIENT_ID")
     client_secret = os.environ.get("STRAVA_CLIENT_SECRET")
@@ -87,11 +335,9 @@ def main() -> None:
         print("Copy .env.example to .env and fill in your credentials.")
         sys.exit(1)
 
-    # Strava auth
     print("Authenticating with Strava…")
     access_token = get_access_token(client_id, client_secret)
 
-    # Incremental sync
     print("Syncing activities…")
     new_count = sync_activities(access_token)
     if new_count:
@@ -99,18 +345,12 @@ def main() -> None:
     else:
         print("  Already up to date.")
 
-    # Build initial history
     activities = get_all_activities()
     prior_messages = get_recent_messages(RECALL_MESSAGES)
     initial_history = build_initial_history(activities, prior_messages)
 
-    # Select backend
     backend = _build_backend(initial_history)
-
-    # Load profile
     profile = load_profile()
-
-    # Chat
     chat(backend, profile)
 
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-markdown": "^9.0.1"
+        "react-markdown": "^9.0.1",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.11",
@@ -746,6 +747,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1077,6 +1112,16 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1117,6 +1162,60 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -1187,6 +1286,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -1462,6 +1566,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -1503,6 +1615,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1518,6 +1740,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -1568,6 +1795,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1624,6 +1856,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -1795,10 +2032,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -2921,6 +3175,12 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "peer": true
+    },
     "node_modules/react-markdown": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
@@ -2945,6 +3205,28 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -2977,6 +3259,45 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -3007,6 +3328,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -3261,6 +3587,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3466,6 +3797,14 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3496,6 +3835,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^9.0.1"
+    "react-markdown": "^9.0.1",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.11",

--- a/web/src/pages/Charts.tsx
+++ b/web/src/pages/Charts.tsx
@@ -1,10 +1,647 @@
-export default function Charts() {
+import { useEffect, useMemo, useState } from "react";
+import {
+  Bar,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Legend,
+  Line,
+  ReferenceArea,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type Unit = "miles" | "km";
+
+interface WeeklyPoint {
+  week: string;
+  distance: number;
+  rolling_avg: number;
+  is_current: boolean;
+}
+
+interface ATLCTLPoint {
+  date: string;
+  atl: number;
+  ctl: number;
+  ratio: number | null;
+}
+
+interface AerobicEffPoint {
+  date: string;
+  efficiency: number;
+  name: string;
+  hr: number;
+  pace_s: number;
+}
+
+interface AerobicEffData {
+  has_enough_data: boolean;
+  qualifying_count: number;
+  scatter: AerobicEffPoint[];
+  rolling_avg: { date: string; avg: number }[];
+  improving: boolean;
+}
+
+interface ChartData {
+  unit: string;
+  weekly_mileage: WeeklyPoint[];
+  atl_ctl: ATLCTLPoint[];
+  aerobic_efficiency: AerobicEffData;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmtPace(s: number) {
+  return `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
+}
+
+function fmtWeekDate(str: string) {
+  return new Date(str + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function fmtTs(ts: number) {
+  return new Date(ts).toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+}
+
+// Dark-theme recharts style props (reused across charts)
+const GRID_COLOR = "#374151";
+const TICK_STYLE = { fill: "#9ca3af", fontSize: 11 };
+const AXIS_LINE = { stroke: "#4b5563" };
+const TOOLTIP_STYLE = {
+  backgroundColor: "#1f2937",
+  border: "1px solid #374151",
+  borderRadius: "6px",
+  color: "#f3f4f6",
+  fontSize: 12,
+};
+const LEGEND_STYLE = { color: "#9ca3af", fontSize: 12 };
+
+// ── Date filter ───────────────────────────────────────────────────────────────
+
+type FilterPreset = "this-month" | "last-month" | "ytd" | "last-3m" | "last-6m" | "last-year" | "all-time" | "custom";
+
+interface DateRange {
+  since: string | null; // YYYY-MM-DD
+  until: string | null;
+}
+
+const PRESETS: { id: FilterPreset; label: string }[] = [
+  { id: "this-month", label: "This Month" },
+  { id: "last-month", label: "Last Month" },
+  { id: "ytd", label: "Year to Date" },
+  { id: "last-3m", label: "Last 3M" },
+  { id: "last-6m", label: "Last 6M" },
+  { id: "last-year", label: "Last Year" },
+  { id: "all-time", label: "All Time" },
+  { id: "custom", label: "Custom" },
+];
+
+function getPresetRange(preset: FilterPreset): DateRange {
+  if (preset === "all-time" || preset === "custom") return { since: null, until: null };
+  const today = new Date();
+  const y = today.getFullYear();
+  const m = today.getMonth();
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  switch (preset) {
+    case "this-month":  return { since: iso(new Date(y, m, 1)), until: null };
+    case "last-month":  return { since: iso(new Date(y, m - 1, 1)), until: iso(new Date(y, m, 0)) };
+    case "ytd":         return { since: `${y}-01-01`, until: null };
+    case "last-3m": { const d = new Date(today); d.setMonth(m - 3); return { since: iso(d), until: null }; }
+    case "last-6m": { const d = new Date(today); d.setMonth(m - 6); return { since: iso(d), until: null }; }
+    case "last-year": { const d = new Date(today); d.setFullYear(y - 1); return { since: iso(d), until: null }; }
+  }
+}
+
+function filterByDate<T>(items: T[], key: keyof T, since: string | null, until: string | null): T[] {
+  if (!since && !until) return items;
+  return items.filter((item) => {
+    const d = String(item[key] ?? "");
+    if (since && d < since) return false;
+    if (until && d > until) return false;
+    return true;
+  });
+}
+
+// ── Weekly Mileage ────────────────────────────────────────────────────────────
+
+function WeeklyMileageChart({ data, unit }: { data: WeeklyPoint[]; unit: Unit }) {
+  const ul = unit === "miles" ? "mi" : "km";
+
   return (
-    <div className="flex items-center justify-center h-full text-gray-500">
-      <div className="text-center">
-        <p className="text-4xl mb-4">📈</p>
-        <p className="text-lg font-medium text-gray-400">Charts coming soon</p>
-        <p className="text-sm mt-1">Weekly mileage, pace trends, HR zones…</p>
+    <section className="bg-gray-900 rounded-lg border border-gray-800 p-5">
+      <h3 className="text-gray-100 font-semibold mb-0.5">Weekly Mileage</h3>
+      <p className="text-gray-500 text-xs mb-4">
+        Per-week totals · 4-week rolling average ·{" "}
+        <span className="text-green-400">■</span> current week
+      </p>
+      <ResponsiveContainer width="100%" height={260}>
+        <ComposedChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
+          <XAxis
+            dataKey="week"
+            tickFormatter={fmtWeekDate}
+            tick={TICK_STYLE}
+            axisLine={AXIS_LINE}
+            tickLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            tick={TICK_STYLE}
+            axisLine={AXIS_LINE}
+            tickLine={false}
+            width={36}
+            tickFormatter={(v) => `${v}${ul}`}
+          />
+          <Tooltip
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            formatter={((val: any, name: any) => [`${Number(val).toFixed(1)} ${ul}`, name]) as any}
+            labelFormatter={(label: unknown) => fmtWeekDate(String(label))}
+            contentStyle={TOOLTIP_STYLE}
+            cursor={{ fill: "#374151", opacity: 0.4 }}
+          />
+          <Legend wrapperStyle={LEGEND_STYLE} />
+          <Bar dataKey="distance" name="Distance" maxBarSize={18} radius={[2, 2, 0, 0]}>
+            {data.map((entry, i) => (
+              <Cell key={i} fill={entry.is_current ? "#4ade80" : "#22d3ee"} opacity={0.85} />
+            ))}
+          </Bar>
+          <Line
+            dataKey="rolling_avg"
+            name="4-week avg"
+            stroke="#fb923c"
+            strokeWidth={2}
+            dot={false}
+            strokeDasharray="5 3"
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </section>
+  );
+}
+
+// ── ATL / CTL ─────────────────────────────────────────────────────────────────
+
+function ATLTooltip({ active, payload, label, unit }: {
+  active?: boolean;
+  payload?: { dataKey: string; value: number }[];
+  label?: string;
+  unit: Unit;
+}) {
+  if (!active || !payload?.length) return null;
+  const get = (key: string) => payload.find((p) => p.dataKey === key)?.value;
+  const atl = get("atl");
+  const ctl = get("ctl");
+  const ratio = get("ratio");
+  const ul = unit === "miles" ? "mi" : "km";
+
+  let zone = "";
+  if (ratio != null) {
+    zone = ratio > 1.3 ? "⚠ Injury risk" : ratio < 0.8 ? "↓ Detraining" : "✓ Optimal";
+  }
+
+  return (
+    <div className="bg-gray-800 border border-gray-700 rounded-md p-2.5 text-xs shadow-lg leading-5">
+      <p className="text-gray-300 font-medium mb-1">{label}</p>
+      {atl != null && <p style={{ color: "#ef4444" }}>ATL: {atl.toFixed(2)} {ul}/day</p>}
+      {ctl != null && <p style={{ color: "#60a5fa" }}>CTL: {ctl.toFixed(2)} {ul}/day</p>}
+      {ratio != null && (
+        <p style={{ color: "#a78bfa" }}>
+          Ratio: {ratio.toFixed(2)} — {zone}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ATLCTLChart({ data, unit }: { data: ATLCTLPoint[]; unit: Unit }) {
+  const ul = unit === "miles" ? "mi" : "km";
+  const ratioMax = Math.max(2.5, ...data.map((d) => d.ratio ?? 0));
+
+  return (
+    <section className="bg-gray-900 rounded-lg border border-gray-800 p-5">
+      <h3 className="text-gray-100 font-semibold mb-0.5">Training Load — ATL / CTL</h3>
+      <p className="text-gray-500 text-xs mb-4">
+        ATL = 7-day EWA · CTL = 42-day EWA · Ratio zones:{" "}
+        <span className="text-green-400">optimal 0.8–1.3</span>
+        {" · "}
+        <span className="text-red-400">injury risk &gt;1.3</span>
+        {" · "}
+        <span className="text-gray-400">detraining &lt;0.8</span>
+      </p>
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart data={data} margin={{ top: 4, right: 52, left: 0, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={fmtWeekDate}
+            tick={TICK_STYLE}
+            axisLine={AXIS_LINE}
+            tickLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            yAxisId="load"
+            tick={TICK_STYLE}
+            axisLine={AXIS_LINE}
+            tickLine={false}
+            width={40}
+            tickFormatter={(v) => `${v.toFixed(1)}`}
+            label={{ value: `${ul}/d`, angle: -90, position: "insideLeft", fill: "#6b7280", fontSize: 10, dx: 10 }}
+          />
+          <YAxis
+            yAxisId="ratio"
+            orientation="right"
+            domain={[0, Math.ceil(ratioMax * 10) / 10]}
+            tick={TICK_STYLE}
+            axisLine={AXIS_LINE}
+            tickLine={false}
+            width={36}
+            label={{ value: "ratio", angle: 90, position: "insideRight", fill: "#6b7280", fontSize: 10, dx: -4 }}
+          />
+
+          {/* Zone shading on ratio axis */}
+          <ReferenceArea yAxisId="ratio" y1={0.8} y2={1.3} fill="#22c55e" fillOpacity={0.07} />
+          <ReferenceArea yAxisId="ratio" y1={1.3} y2={Math.ceil(ratioMax * 10) / 10} fill="#ef4444" fillOpacity={0.07} />
+          <ReferenceArea yAxisId="ratio" y1={0} y2={0.8} fill="#6b7280" fillOpacity={0.07} />
+
+          <Tooltip content={<ATLTooltip unit={unit} />} />
+          <Legend wrapperStyle={LEGEND_STYLE} />
+
+          <Line yAxisId="load" dataKey="atl" name="ATL (7d)" stroke="#ef4444" strokeWidth={1.5} dot={false} />
+          <Line yAxisId="load" dataKey="ctl" name="CTL (42d)" stroke="#60a5fa" strokeWidth={1.5} dot={false} />
+          <Line
+            yAxisId="ratio"
+            dataKey="ratio"
+            name="ATL/CTL"
+            stroke="#a78bfa"
+            strokeWidth={1.5}
+            dot={false}
+            strokeDasharray="5 3"
+            connectNulls={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </section>
+  );
+}
+
+// ── Aerobic Efficiency ────────────────────────────────────────────────────────
+
+function AerobicEffTooltip({ active, payload }: { active?: boolean; payload?: { payload: unknown }[] }) {
+  if (!active || !payload?.length) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const p = payload[0]?.payload as any;
+  // Rolling-avg points have no run-level fields — skip them
+  if (!p || p.date == null || p.efficiency == null) return null;
+  return (
+    <div className="bg-gray-800 border border-gray-700 rounded-md p-2.5 text-xs shadow-lg leading-5">
+      <p className="text-gray-400">{String(p.date)}</p>
+      {p.name && <p className="text-gray-100 font-medium">{String(p.name)}</p>}
+      <p className="text-gray-300">
+        Efficiency: <span className="text-white">{Number(p.efficiency).toFixed(2)}</span>
+      </p>
+      <p className="text-gray-300">
+        HR: <span className="text-white">{p.hr} bpm</span>
+      </p>
+      <p className="text-gray-300">
+        Pace: <span className="text-white">{fmtPace(Number(p.pace_s))}/{String(p.ul)}</span>
+      </p>
+    </div>
+  );
+}
+
+// Custom shape that renders the "↑ improving" annotation at the last rolling-avg point
+function ImprovingLabel(props: Record<string, unknown>) {
+  const cx = Number(props.cx ?? 0);
+  const cy = Number(props.cy ?? 0);
+  return (
+    <text x={cx + 8} y={cy - 5} fill="#4ade80" fontSize={10} fontStyle="italic" fontFamily="inherit">
+      ↑ improving
+    </text>
+  );
+}
+
+function AerobicEfficiencyChart({ data, unit }: { data: AerobicEffData; unit: Unit }) {
+  const ul = unit === "miles" ? "mi" : "km";
+  const { has_enough_data, qualifying_count, scatter, rolling_avg, improving } = data;
+
+  // Convert to {x: timestamp, y: value, ...} for ScatterChart
+  const scatterXY = useMemo(
+    () => scatter.map((p) => ({ x: new Date(p.date + "T00:00:00").getTime(), y: p.efficiency, ul, ...p })),
+    [scatter, ul],
+  );
+  const rollingXY = useMemo(
+    () => rolling_avg.map((r) => ({ x: new Date(r.date + "T00:00:00").getTime(), y: r.avg })),
+    [rolling_avg],
+  );
+  const lastRollingPoint = useMemo(
+    () => (rollingXY.length > 0 ? [rollingXY[rollingXY.length - 1]] : []),
+    [rollingXY],
+  );
+
+  const allY = scatterXY.map((p) => p.y);
+  const minY = allY.length ? Math.min(...allY) : 0;
+  const maxY = allY.length ? Math.max(...allY) : 1;
+  const pad = (maxY - minY) * 0.12 || 0.2;
+
+  // Not enough qualifying runs overall
+  if (!has_enough_data) {
+    const needed = 10 - qualifying_count;
+    return (
+      <section className="bg-gray-900 rounded-lg border border-gray-800 p-5">
+        <h3 className="text-gray-100 font-semibold mb-3">Aerobic Efficiency</h3>
+        <div className="flex gap-4 items-start py-6 px-4">
+          <span className="text-3xl">🫀</span>
+          <div>
+            <p className="text-gray-300 text-sm font-medium mb-1">
+              {needed} more qualifying {needed === 1 ? "run" : "runs"} needed
+            </p>
+            <p className="text-gray-500 text-xs leading-relaxed max-w-lg">
+              Aerobic efficiency tracks your running speed relative to heart rate — higher means
+              you&apos;re covering more ground per heartbeat, a reliable signal of improving fitness.
+              It will appear once you have 10 runs logged with average HR between 120–155 bpm
+              (easy to moderate effort, excluding warm-ups, races, and sensor dropouts).
+            </p>
+            {qualifying_count > 0 && (
+              <p className="text-green-500/80 text-xs mt-2">
+                {qualifying_count} qualifying {qualifying_count === 1 ? "run" : "runs"} recorded so far.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  // Enough data overall but nothing visible in the current filter window
+  if (scatterXY.length < 3) {
+    return (
+      <section className="bg-gray-900 rounded-lg border border-gray-800 p-5">
+        <h3 className="text-gray-100 font-semibold mb-1">Aerobic Efficiency</h3>
+        <p className="text-gray-500 text-sm text-center py-10">
+          No qualifying runs (120–155 bpm) in this date range.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="bg-gray-900 rounded-lg border border-gray-800 p-5">
+      <div className="flex items-center gap-2 mb-0.5">
+        <h3 className="text-gray-100 font-semibold">Aerobic Efficiency</h3>
+        {improving && (
+          <span className="text-green-400 text-xs bg-green-500/10 border border-green-500/20 rounded-full px-2 py-0.5">
+            ↑ Improving
+          </span>
+        )}
+      </div>
+      <p className="text-gray-500 text-xs mb-4">
+        Speed / HR for easy efforts (120–155 bpm) · 4-week rolling average · higher = fitter
+      </p>
+      <ResponsiveContainer width="100%" height={280}>
+        <ScatterChart margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} />
+          <XAxis
+            type="number"
+            dataKey="x"
+            scale="time"
+            domain={["dataMin", "dataMax"]}
+            tickFormatter={fmtTs}
+            tick={TICK_STYLE}
+            axisLine={AXIS_LINE}
+            tickLine={false}
+            name="Date"
+          />
+          <YAxis
+            type="number"
+            dataKey="y"
+            domain={[minY - pad, maxY + pad]}
+            tickFormatter={(v: number) => v.toFixed(2)}
+            tick={TICK_STYLE}
+            axisLine={AXIS_LINE}
+            tickLine={false}
+            width={44}
+            name="Efficiency"
+            label={{ value: "Efficiency", angle: -90, position: "insideLeft", fill: "#6b7280", fontSize: 10, dx: 14 }}
+          />
+          <Tooltip
+            content={<AerobicEffTooltip />}
+            cursor={{ strokeDasharray: "3 3", stroke: "#4b5563" }}
+          />
+          <Legend wrapperStyle={LEGEND_STYLE} />
+
+          {/* Individual run dots */}
+          <Scatter name={`Easy runs (120–155 bpm)`} data={scatterXY} fill="#22d3ee" opacity={0.65} />
+
+          {/* 4-week rolling average line */}
+          <Scatter
+            data={rollingXY}
+            line={{ stroke: "#4ade80", strokeWidth: 2.5 }}
+            shape={() => null}
+            legendType="none"
+            name="rolling-avg"
+          />
+
+          {/* "↑ improving" label anchored to the last rolling-avg point */}
+          {improving && lastRollingPoint.length > 0 && (
+            <Scatter
+              data={lastRollingPoint}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              shape={(props: any) => <ImprovingLabel {...props} />}
+              legendType="none"
+              name="improving-label"
+            />
+          )}
+        </ScatterChart>
+      </ResponsiveContainer>
+    </section>
+  );
+}
+
+// ── Filter bar ────────────────────────────────────────────────────────────────
+
+function FilterBar({
+  preset,
+  customSince,
+  customUntil,
+  onPreset,
+  onCustomSince,
+  onCustomUntil,
+}: {
+  preset: FilterPreset;
+  customSince: string;
+  customUntil: string;
+  onPreset: (p: FilterPreset) => void;
+  onCustomSince: (v: string) => void;
+  onCustomUntil: (v: string) => void;
+}) {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-lg p-3 flex flex-wrap items-center gap-1.5">
+      {PRESETS.map(({ id, label }) => (
+        <button
+          key={id}
+          onClick={() => onPreset(id)}
+          className={`px-3 py-1 text-xs rounded-md border transition-colors ${
+            preset === id
+              ? "bg-green-500/20 text-green-400 border-green-500/30 font-medium"
+              : "text-gray-400 border-gray-700 hover:bg-gray-800 hover:text-gray-200"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+      {preset === "custom" && (
+        <div className="flex items-center gap-2 ml-1">
+          <input
+            type="date"
+            value={customSince}
+            onChange={(e) => onCustomSince(e.target.value)}
+            className="bg-gray-800 text-gray-200 border border-gray-600 rounded px-2 py-0.5 text-xs focus:outline-none focus:border-green-500"
+            style={{ colorScheme: "dark" }}
+          />
+          <span className="text-gray-500 text-xs">→</span>
+          <input
+            type="date"
+            value={customUntil}
+            onChange={(e) => onCustomUntil(e.target.value)}
+            className="bg-gray-800 text-gray-200 border border-gray-600 rounded px-2 py-0.5 text-xs focus:outline-none focus:border-green-500"
+            style={{ colorScheme: "dark" }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+export default function Charts() {
+  const [unit, setUnit] = useState<Unit>(() => {
+    return (localStorage.getItem("strides_unit") as Unit) || "miles";
+  });
+  const [data, setData] = useState<ChartData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [preset, setPreset] = useState<FilterPreset>("all-time");
+  const [customSince, setCustomSince] = useState("");
+  const [customUntil, setCustomUntil] = useState("");
+
+  useEffect(() => {
+    localStorage.setItem("strides_unit", unit);
+    setLoading(true);
+    setError(null);
+    fetch(`/api/charts?unit=${unit}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((d) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setError(e.message);
+        setLoading(false);
+      });
+  }, [unit]);
+
+  // Resolve the active date range
+  const range = useMemo((): DateRange => {
+    if (preset === "custom") return { since: customSince || null, until: customUntil || null };
+    return getPresetRange(preset);
+  }, [preset, customSince, customUntil]);
+
+  // Apply filter and recompute trends
+  const filtered = useMemo(() => {
+    if (!data) return null;
+    const { since, until } = range;
+    const isAllTime = preset === "all-time";
+
+    const weekly = filterByDate(data.weekly_mileage, "week", since, until);
+    const atlCtl = filterByDate(data.atl_ctl, "date", since, until);
+    const ae = data.aerobic_efficiency;
+    const aeFiltered: AerobicEffData = {
+      ...ae,
+      scatter:     filterByDate(ae.scatter,     "date", since, until),
+      rolling_avg: filterByDate(ae.rolling_avg, "date", since, until),
+      // improving always reflects the real last-4-weeks vs previous-4-weeks
+    };
+
+    return {
+      ...data,
+      weekly_mileage:     isAllTime ? weekly.slice(-52)  : weekly,
+      atl_ctl:            isAllTime ? atlCtl.slice(-365) : atlCtl,
+      aerobic_efficiency: aeFiltered,
+    };
+  }, [data, range, preset]);
+
+  const empty = filtered && filtered.weekly_mileage.length === 0 && filtered.atl_ctl.length === 0 && filtered.aerobic_efficiency.scatter.length === 0;
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-6 space-y-5 max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-bold text-gray-100">Training Charts</h2>
+          <div className="flex rounded-md overflow-hidden border border-gray-700 text-sm">
+            {(["miles", "km"] as Unit[]).map((u) => (
+              <button
+                key={u}
+                onClick={() => setUnit(u)}
+                className={`px-4 py-1.5 transition-colors ${
+                  unit === u
+                    ? "bg-green-500/20 text-green-400 font-medium"
+                    : "text-gray-400 hover:bg-gray-800"
+                }`}
+              >
+                {u === "miles" ? "Miles" : "km"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <FilterBar
+          preset={preset}
+          customSince={customSince}
+          customUntil={customUntil}
+          onPreset={setPreset}
+          onCustomSince={setCustomSince}
+          onCustomUntil={setCustomUntil}
+        />
+
+        {loading && (
+          <div className="flex items-center justify-center py-24 text-gray-500">
+            <span className="animate-pulse">Loading chart data…</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-950 border border-red-800 text-red-300 rounded-lg p-4 text-sm">
+            Failed to load charts: {error}
+          </div>
+        )}
+
+        {empty && (
+          <div className="text-center py-16 text-gray-500">
+            No activities in this date range.
+          </div>
+        )}
+
+        {filtered && !loading && !empty && (
+          <>
+            <WeeklyMileageChart data={filtered.weekly_mileage} unit={unit} />
+            <ATLCTLChart data={filtered.atl_ctl} unit={unit} />
+            <AerobicEfficiencyChart data={filtered.aerobic_efficiency} unit={unit} />
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Weekly Mileage**: Bar chart of weekly totals (Mon–Sun) with a 4-week rolling average line; current week highlighted in a distinct color
- **ATL/CTL Training Load**: Dual-axis chart of Acute (7-day EWA) and Chronic (42-day EWA) training load, plus their ratio; shaded zones for optimal training (0.8–1.3), detraining (<0.8), and injury risk (>1.3)
- **Aerobic Efficiency**: Scatter of speed/HR for easy-effort runs (HR 120–155 bpm), 28-day rolling average trend line, and a subtle "↑ improving" annotation when the last 4 weeks outperform the previous 4; friendly onboarding message when fewer than 10 qualifying runs exist
- **Date filter bar**: quick presets (This Month, Last Month, YTD, Last 3M, Last 6M, Last Year, All Time) plus custom date range inputs
- **Miles/km unit toggle** persisted to `localStorage`
- **`strides-ai charts` CLI command**: matplotlib 3-subplot dark-themed figure with ATL/CTL hover tooltips; saves PNG and opens interactively

## Files changed

| File | Change |
|---|---|
| `strides_ai/charts_data.py` | New — all chart computation logic |
| `strides_ai/api/app.py` | New `GET /api/charts?unit=` endpoint |
| `strides_ai/cli.py` | New `charts` subcommand with matplotlib output |
| `pyproject.toml` | Added `matplotlib>=3.7` dependency |
| `web/package.json` | Added `recharts` dependency |
| `web/src/pages/Charts.tsx` | Full implementation (was placeholder) |

## Test plan

- [ ] `make install` succeeds (matplotlib + recharts installed)
- [ ] `strides-ai charts` opens matplotlib window with 3 subplots; ATL/CTL hover shows tooltip
- [ ] `strides-ai charts --unit km --output /tmp/charts.png` saves file without opening window
- [ ] `make dev` starts both servers; navigate to `#charts` tab
- [ ] All three charts render with real data
- [ ] Date filter presets narrow the data correctly; custom date inputs work
- [ ] Unit toggle switches labels between mi and km and refetches data
- [ ] With fewer than 10 HR-qualifying runs, Aerobic Efficiency shows the onboarding message

🤖 Generated with [Claude Code](https://claude.com/claude-code)