### PR TITLE
fix: proxy /uploads through Vite dev server

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.11
+        language_version: python3
 
   - repo: local
     hooks:

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": "http://localhost:8000",
+      "/uploads": "http://localhost:8000",
     },
   },
 });


### PR DESCRIPTION
## Summary

- Images attached in chat are saved to disk and served by FastAPI at `/uploads/<uuid>`. The Vite dev server proxy only forwarded `/api` routes, so when those image markdown references were loaded from history (`![name](/uploads/...)`) they resolved to `localhost:5173/uploads/...` and returned 404s — showing a broken image.
- Added `/uploads` to the Vite proxy so image requests go through to the FastAPI backend at `:8000`.
- Also fixed the `pre-commit` black hook's `language_version` from `python3.11` to `python3` (system Python is 3.12).

## Test plan

- [ ] Send a message with an image attachment
- [ ] Refresh the page — image should still render correctly when loaded from history
- [ ] Confirm `git commit` runs black and tests without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)