### PR TITLE
feat(settings): add Full Sync button for manual Strava rehydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Switch between modes from the **Settings** tab. The active mode affects:
 - **Conversation history** — each mode has its own separate history so advice stays contextually relevant
 - **Athlete profile** — running and cycling profiles can be filled in independently
 
-After switching modes, sync your activities with `POST /api/sync?full=true` if you haven't done a full sync before, to ensure all sport types are in the database.
+After switching modes for the first time, use the **Full Sync** button in the **Settings** tab to fetch your complete Strava history and ensure all sport types are in the database.
 
 ---
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import type { Mode, ThemeConfig } from "../App";
 
 interface Props {
@@ -41,7 +41,12 @@ const MODE_CARDS: {
   },
 ];
 
-export default function Settings({ mode, setMode }: Props) {
+type SyncState = "idle" | "syncing" | "done" | "error";
+
+export default function Settings({ mode, setMode, theme }: Props) {
+  const [syncState, setSyncState] = useState<SyncState>("idle");
+  const [syncCount, setSyncCount] = useState<number | null>(null);
+
   async function handleModeChange(newMode: Mode) {
     try {
       await fetch("/api/settings", {
@@ -56,13 +61,27 @@ export default function Settings({ mode, setMode }: Props) {
     location.hash = "chat";
   }
 
+  async function handleFullSync() {
+    setSyncState("syncing");
+    setSyncCount(null);
+    try {
+      const res = await fetch("/api/sync?full=true", { method: "POST" });
+      if (!res.ok) throw new Error();
+      const { new_activities } = await res.json();
+      setSyncCount(new_activities);
+      setSyncState("done");
+    } catch {
+      setSyncState("error");
+    }
+  }
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-2xl mx-auto px-6 py-10">
         <h2 className="text-xl font-semibold text-gray-100 mb-1">Settings</h2>
         <p className="text-sm text-gray-500 mb-8">Configure your Strides AI preferences.</p>
 
-        <div className="space-y-6">
+        <div className="space-y-8">
           <section>
             <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
               Mode
@@ -79,14 +98,14 @@ export default function Settings({ mode, setMode }: Props) {
                     key={card.id}
                     onClick={() => handleModeChange(card.id)}
                     className={`w-full text-left p-4 rounded-lg border-2 transition-colors bg-gray-900 ${
-                      selected
-                        ? card.borderSelected
-                        : "border-gray-700 hover:border-gray-500"
+                      selected ? card.borderSelected : "border-gray-700 hover:border-gray-500"
                     }`}
                   >
                     <div className="flex items-center gap-3 mb-1">
                       <span className={`w-2 h-2 rounded-full shrink-0 ${card.dotClass}`} />
-                      <span className={`font-medium text-sm ${selected ? card.accentClass : "text-gray-200"}`}>
+                      <span
+                        className={`font-medium text-sm ${selected ? card.accentClass : "text-gray-200"}`}
+                      >
                         {card.label}
                       </span>
                       {selected && (
@@ -97,6 +116,35 @@ export default function Settings({ mode, setMode }: Props) {
                   </button>
                 );
               })}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+              Strava Sync
+            </h3>
+            <p className="text-xs text-gray-600 mb-3">
+              Re-fetches your complete Strava activity history. Use this after switching modes for
+              the first time, or to rehydrate the database after moving to a new machine.
+            </p>
+            <div className="flex items-center gap-4">
+              <button
+                onClick={handleFullSync}
+                disabled={syncState === "syncing"}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${theme.accentButton} text-white`}
+              >
+                {syncState === "syncing" ? "Syncing…" : "Full Sync"}
+              </button>
+              {syncState === "done" && (
+                <span className="text-xs text-gray-400">
+                  {syncCount === 0
+                    ? "Already up to date."
+                    : `${syncCount} new activit${syncCount === 1 ? "y" : "ies"} synced.`}
+                </span>
+              )}
+              {syncState === "error" && (
+                <span className="text-xs text-red-400">Sync failed. Check your Strava credentials.</span>
+              )}
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Summary

- Adds a **Full Sync** button to the Settings page that calls `POST /api/sync?full=true`
- Shows inline status: "Syncing…" while in progress, count of new activities on success, or an error message on failure
- Removes the `POST /api/sync?full=true` curl instruction from the README, replacing it with a reference to the new button

## Test plan

- [x] Open Settings tab — Full Sync section is visible below the mode cards
- [x] Click Full Sync — button shows "Syncing…" and is disabled while running
- [x] On success — "N new activities synced." or "Already up to date." appears
- [ ] With bad Strava credentials — error message appears
- [x] README no longer mentions the curl command

🤖 Generated with [Claude Code](https://claude.com/claude-code)