### PR TITLE
feat(profile): add preferred snacks list for nutrition loadout advice

### DIFF
--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -23,6 +23,10 @@ injury prevention, and periodisation.
 - Be concise but thorough. When referencing specific runs, cite the date and \
 key metrics (distance, pace, HR).
 - Use metric units (km, min/km) unless the athlete asks otherwise.
+- When advising on nutrition for a run, suggest a concrete sample loadout \
+(e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
+preferred snacks in their profile, choose from those; otherwise use sensible \
+defaults based on run distance and intensity.
 
 The athlete's full training log is embedded in the next message as structured \
 text. Treat it as ground truth for all data-related questions.
@@ -43,6 +47,10 @@ injury prevention, and periodisation for cyclists.
 - Be concise but thorough. When referencing specific rides, cite the date and \
 key metrics (distance, speed, HR).
 - Use metric units (km, km/h) unless the athlete asks otherwise.
+- When advising on nutrition for a ride, suggest a concrete sample loadout \
+(e.g. "2 gels, 1 energy bar, 750 ml electrolytes"). If the athlete has listed \
+preferred snacks in their profile, choose from those; otherwise use sensible \
+defaults based on ride duration and intensity.
 
 The athlete's full training log is embedded in the next message as structured \
 text. Treat it as ground truth for all data-related questions.
@@ -63,6 +71,10 @@ pacing, recovery, race preparation, injury prevention, and periodisation.
 - Be concise but thorough. When referencing specific activities, cite the date, \
 sport type, and key metrics.
 - Use metric units unless the athlete asks otherwise.
+- When advising on nutrition for any activity, suggest a concrete sample loadout \
+(e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
+preferred snacks in their profile, choose from those; otherwise use sensible \
+defaults based on activity duration and intensity.
 
 The athlete's full training log is embedded in the next message as structured \
 text. Treat it as ground truth for all data-related questions.

--- a/strides_ai/profile.py
+++ b/strides_ai/profile.py
@@ -27,6 +27,7 @@ RUNNING_DEFAULTS: dict = {
     "goals": "",
     "injuries_and_health": "",
     "gear": "",
+    "nutrition_snacks": [],
     "other_notes": "",
 }
 
@@ -52,6 +53,7 @@ CYCLING_DEFAULTS: dict = {
     "goals": "",
     "injuries_and_health": "",
     "gear": "",
+    "nutrition_snacks": [],
     "other_notes": "",
 }
 
@@ -88,6 +90,7 @@ HYBRID_DEFAULTS: dict = {
     "goals": "",
     "injuries_and_health": "",
     "gear": "",
+    "nutrition_snacks": [],
     "other_notes": "",
 }
 
@@ -210,6 +213,15 @@ def profile_to_text(fields: dict | None, mode: str) -> str:
         val = _v(fields.get(key))
         if val:
             sections.append(f"### {title}\n{val}")
+
+    snacks = fields.get("nutrition_snacks", [])
+    if isinstance(snacks, list):
+        snack_items = [s.strip() for s in snacks if str(s).strip()]
+    else:
+        snack_items = [s.strip() for s in str(snacks).splitlines() if s.strip()]
+    if snack_items:
+        bullet_list = "\n".join(f"- {s}" for s in snack_items)
+        sections.append(f"### Preferred Nutrition & Snacks\n{bullet_list}")
 
     if not sections:
         return ""

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -182,6 +182,7 @@ def test_get_default_fields_running_keys():
         "goals",
         "injuries_and_health",
         "gear",
+        "nutrition_snacks",
         "other_notes",
     }
 
@@ -195,6 +196,7 @@ def test_get_default_fields_cycling_keys():
         "goals",
         "injuries_and_health",
         "gear",
+        "nutrition_snacks",
         "other_notes",
     }
 

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -79,15 +79,97 @@ function Section({
   );
 }
 
+// ── Snacks list ───────────────────────────────────────────────────────────────
+
+function SnacksList({
+  snacks,
+  onChange,
+  focusClass,
+}: {
+  snacks: string[];
+  onChange: (v: string[]) => void;
+  focusClass: string;
+}) {
+  const [input, setInput] = useState("");
+
+  function add() {
+    const val = input.trim();
+    if (!val || snacks.includes(val)) return;
+    onChange([...snacks, val]);
+    setInput("");
+  }
+
+  function remove(i: number) {
+    onChange(snacks.filter((_, idx) => idx !== i));
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      add();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <label className="text-xs font-medium text-gray-400">
+        Preferred snacks &amp; fuel — the coach will pick from this list when suggesting nutrition loadouts
+      </label>
+      {snacks.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {snacks.map((s, i) => (
+            <span
+              key={i}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-800 border border-gray-700 text-sm text-gray-200"
+            >
+              {s}
+              <button
+                type="button"
+                onClick={() => remove(i)}
+                className="text-gray-500 hover:text-red-400 transition-colors leading-none"
+                aria-label={`Remove ${s}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="e.g. Maurten Gel 100, Clif Bar, Medjool dates…"
+          className={`flex-1 rounded-md bg-gray-900 border border-gray-700 px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none ${focusClass}`}
+        />
+        <button
+          type="button"
+          onClick={add}
+          disabled={!input.trim()}
+          className="px-3 py-2 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // ── Common lower sections ─────────────────────────────────────────────────────
 
 function CommonSections({
   fields,
   setFields,
+  setFieldsRaw,
   focusClass,
 }: {
-  fields: Record<string, string>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fields: Record<string, any>;
   setFields: (key: string, val: string) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setFieldsRaw: (key: string, val: any) => void;
   focusClass: string;
 }) {
   return (
@@ -119,6 +201,13 @@ function CommonSections({
           onChange={(v) => setFields("gear", v)}
           placeholder="e.g. Nike Vaporfly (~400 km), Garmin Forerunner 955…"
           rows={3}
+          focusClass={focusClass}
+        />
+      </Section>
+      <Section title="Nutrition & Snacks">
+        <SnacksList
+          snacks={Array.isArray(fields.nutrition_snacks) ? fields.nutrition_snacks : []}
+          onChange={(v) => setFieldsRaw("nutrition_snacks", v)}
           focusClass={focusClass}
         />
       </Section>
@@ -195,7 +284,8 @@ export default function Profile({ mode, theme }: Props) {
     setFields((f) => ({ ...f, [section]: { ...f[section], [key]: val } }));
   }
 
-  function setTop(key: string, val: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function setTop(key: string, val: any) {
     setFields((f) => ({ ...f, [key]: val }));
   }
 
@@ -377,7 +467,7 @@ export default function Profile({ mode, theme }: Props) {
           )}
 
           {/* Common lower sections */}
-          <CommonSections fields={fields} setFields={setTop} focusClass={focusClass} />
+          <CommonSections fields={fields} setFields={setTop} setFieldsRaw={setTop} focusClass={focusClass} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Adds a `nutrition_snacks` array field to all three mode profiles (running, cycling, hybrid) — stored in the DB alongside other profile fields
- `profile_to_text()` emits the snack list as bullets in the system prompt so the coach sees it every session
- All three coach system prompts now instruct the LLM to suggest a **concrete sample nutrition loadout** (e.g. "2 gels, 1 granola bar, 500 ml electrolytes"), pulling from the athlete's listed snacks when available, or falling back to sensible defaults based on distance/intensity
- New **Nutrition & Snacks** section on the Profile page with an interactive pill-tag UI: type a snack, press Enter or click Add; click × to remove

## Test plan

- [x] Open Profile page → Nutrition & Snacks section appears for all modes
- [x] Add snacks via input + Enter and via Add button; verify pills appear
- [x] Remove a snack with ×; verify it disappears
- [x] Save profile, reload — snacks persist
- [x] Ask the coach "what should I eat for my long run?" — should reference your listed snacks in the loadout suggestion
- [x] With no snacks listed, coach still suggests a default loadout

🤖 Generated with [Claude Code](https://claude.com/claude-code)