### PR TITLE
feat(ui): mobile-responsive layout with dynamic model settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -153,9 +153,10 @@ export default function App() {
   }
 
   const allNavTabs: { id: Tab; label: string }[] = [...TABS, { id: "settings", label: "Settings" }];
+  const mobileNavTabs = allNavTabs.filter((t) => t.id !== "calendar");
 
   return (
-    <div className="flex h-screen bg-gray-950 text-gray-100">
+    <div className="flex h-dvh bg-gray-950 text-gray-100">
       {/* Sidebar — desktop only */}
       <nav className="hidden md:flex w-48 shrink-0 bg-gray-900 border-r border-gray-800 flex-col">
         <div className="p-4 border-b border-gray-800">
@@ -206,7 +207,7 @@ export default function App() {
 
       {/* Bottom nav — mobile only */}
       <nav className="md:hidden fixed bottom-0 inset-x-0 bg-gray-900 border-t border-gray-800 flex z-20">
-        {allNavTabs.map((t) => (
+        {mobileNavTabs.map((t) => (
           <button
             key={t.id}
             onClick={() => navigate(t.id)}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+  background-color: #030712; /* gray-950 — prevents white flash on mobile keyboard open */
+  height: 100%;
+}
+
 /* Coach message markdown styles */
 .coach-message h1, .coach-message h2, .coach-message h3 {
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Responsive layout with mobile bottom nav bar (hides calendar tab on mobile)
- Fixes white gap appearing when keyboard opens on mobile
- Improved chat UI for mobile viewports
- Fetch available models dynamically from provider APIs (Claude, Gemini, Ollama)
- Remove hardcoded Gemini default model
- Expose Vite dev server on all network interfaces for local network testing

## Test plan
- [ ] Open app on mobile browser — bottom nav should appear, no calendar tab
- [ ] Focus a chat input on mobile — no white gap below keyboard
- [ ] Go to Settings → confirm model list populates from the active provider's API
- [ ] Switch providers (Claude/Gemini/Ollama) — model list should update accordingly
- [ ] Dev server accessible from other devices on local network via host IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)