### PR TITLE
feat(analysis): run analysis pipeline with deep dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A local AI multisport coach that connects to your Strava account and lets you ha
 - **Conversation history** — the last 40 messages from previous sessions are reloaded so coaching advice stays consistent across conversations. History is scoped per mode.
 - **Training calendar** — plan upcoming workouts on a calendar, overlay your actual Strava activities, and get AI-powered nutrition recommendations per workout.
 - **Swappable backends** — run Claude, Gemini, or ChatGPT in the cloud, or a local model via Ollama. Switch providers live from the Settings tab without restarting the server.
+- **Run analysis pipeline** — every synced activity is automatically enriched with derived fitness metrics (cardiac decoupling, HR zone distribution, pace fade, cadence consistency, effort efficiency) and a natural language summary. The Activities tab shows colour-coded metric badges and an on-demand Deep Dive button that generates a full LLM coaching analysis for any individual run.
 
 ## Setup
 
@@ -65,7 +66,7 @@ On first run, a browser window opens to Strava's authorization page — approve 
 | Tab | What it does |
 |---|---|
 | Coach | Streaming chat with your AI coach; conversation persists across sessions and is scoped to the active mode |
-| Activities | Your full Strava history filtered by active mode — sortable, filterable, links to each activity on Strava |
+| Activities | Your full Strava history filtered by active mode — sortable, filterable, analysis badges, Deep Dive button |
 | Charts | Training visualisations: weekly volume with 4-week rolling average, ATL/CTL fitness & fatigue curves, aerobic efficiency scatter plot |
 | Calendar | Plan upcoming workouts, see actual Strava activities overlaid, and get AI nutrition advice per workout |
 | Profile | Structured editor for your athlete profile (per-mode) |
@@ -193,6 +194,59 @@ Tool use and memory saving work with models that support function calling (llama
 
 ---
 
+## Run Analysis Pipeline
+
+Every activity synced from Strava is automatically analysed using time-series stream data (heartrate, velocity, cadence, altitude). Results are stored as flat columns on each activity record and surfaced in the Activities tab and to the AI coach.
+
+### Computed metrics
+
+| Metric | Description | Threshold |
+|---|---|---|
+| **Cardiac decoupling %** | Aerobic efficiency — how much the HR/pace ratio drifts across the run | <5% excellent, 5–10% acceptable, >10% high stress |
+| **HR zones (Z1–Z5)** | Time distribution across HR intensity zones (based on `max_hr` setting, default 190) | Z1 recovery, Z2 aerobic, Z3 tempo, Z4 threshold, Z5 VO2max |
+| **Pace fade (sec/mile)** | Last-third avg pace minus first-third avg pace | Positive = slowing, negative = negative split |
+| **Cadence avg / std dev** | Mean and variability of step rate (spm for runs, rpm for rides) | — |
+| **Effort efficiency score** | 0–100, normalized across athlete history; higher = better pace for a given HR | — |
+| **Elevation per mile** | Total elevation gain in ft/mile; flags hilly courses (>100 ft/mile) | — |
+| **Suffer score validation** | Cross-checks Strava's suffer score against computed HR zone distribution | Flags potential HR sensor issues |
+
+### Analysis summary
+
+After computing metrics, a short rule-based natural language summary is generated (no LLM call, no cost). Example:
+
+> _"Strong aerobic run — 3.2% cardiac decoupling. 81% time in Z1/Z2. Pace held steady throughout."_
+
+This summary appears as a subtitle under the activity name in the Activities tab and as an ANALYSIS column in the training log the coach reads.
+
+### Configuring max HR
+
+The HR zone thresholds use `max_hr` from the settings table (default 190 bpm). To set your actual max HR, use the Strava API or set it via a future settings UI. The DB key is `max_hr`.
+
+### Backfilling existing activities
+
+On every sync, the pipeline also backfills up to 10 activities that were previously synced without analysis. To trigger a full backfill:
+
+```bash
+# From Settings tab — use the "Full Sync" button
+# Or via API:
+curl -X POST "http://localhost:8000/api/sync?full=true"
+```
+
+Rate limits are handled gracefully: if Strava returns 429, remaining activities are marked `analysis_status='pending'` and retried on the next sync.
+
+### Deep Dive
+
+Click **Deep Dive** on any activity row to generate a detailed LLM coaching analysis for that specific run. The deep dive:
+
+1. Fetches the full time-series stream from Strava
+2. Downsamples to 60-second intervals plus key inflection points (pace surges, HR spikes)
+3. Sends to the active LLM backend (Claude, Gemini, Ollama, or ChatGPT) with a coaching analysis prompt
+4. Returns a 4–6 paragraph analysis covering pacing strategy, HR drift, cadence patterns, elevation impact, and actionable coaching notes
+
+Results are cached — clicking the button again shows the saved report instantly. Use **Regenerate** to force a fresh analysis.
+
+---
+
 ## How it works
 
 ```
@@ -206,6 +260,7 @@ strides_ai/
 │   ├── gemini.py   # Google Gemini SDK, function calling loop
 │   ├── openai.py   # OpenAI SDK, streaming + tool calling loop
 │   └── ollama.py   # httpx → Ollama /api/chat, streaming + tools
+├── analysis.py     # Stream fetching, metric computation, NL summary, deep-dive formatting
 ├── auth.py         # Strava OAuth2 — token exchange, storage, auto-refresh
 ├── db.py           # SQLite — activities, history, memories, profiles, calendar
 ├── sync.py         # Strava API pagination, incremental sync (runs + rides)

--- a/alembic/versions/002_activity_analysis_columns.py
+++ b/alembic/versions/002_activity_analysis_columns.py
@@ -1,0 +1,56 @@
+"""Add run analysis columns to activities table.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-03-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "002"
+down_revision = "001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.add_column(sa.Column("cardiac_decoupling_pct", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("hr_zone_1_pct", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("hr_zone_2_pct", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("hr_zone_3_pct", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("hr_zone_4_pct", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("hr_zone_5_pct", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("pace_fade_seconds", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("cadence_std_dev", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("effort_efficiency_raw", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("effort_efficiency_score", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("elevation_per_mile", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("high_elevation_flag", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("suffer_score_mismatch_flag", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("analysis_summary", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("deep_dive_report", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("deep_dive_completed_at", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("analysis_status", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.drop_column("analysis_status")
+        batch_op.drop_column("deep_dive_completed_at")
+        batch_op.drop_column("deep_dive_report")
+        batch_op.drop_column("analysis_summary")
+        batch_op.drop_column("suffer_score_mismatch_flag")
+        batch_op.drop_column("high_elevation_flag")
+        batch_op.drop_column("elevation_per_mile")
+        batch_op.drop_column("effort_efficiency_score")
+        batch_op.drop_column("effort_efficiency_raw")
+        batch_op.drop_column("cadence_std_dev")
+        batch_op.drop_column("pace_fade_seconds")
+        batch_op.drop_column("hr_zone_5_pct")
+        batch_op.drop_column("hr_zone_4_pct")
+        batch_op.drop_column("hr_zone_3_pct")
+        batch_op.drop_column("hr_zone_2_pct")
+        batch_op.drop_column("hr_zone_1_pct")
+        batch_op.drop_column("cardiac_decoupling_pct")

--- a/alembic/versions/003_user_notes.py
+++ b/alembic/versions/003_user_notes.py
@@ -1,0 +1,24 @@
+"""Add user_notes column to activities table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-03-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.add_column(sa.Column("user_notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.drop_column("user_notes")

--- a/alembic/versions/004_deep_dive_model.py
+++ b/alembic/versions/004_deep_dive_model.py
@@ -1,0 +1,24 @@
+"""Add deep_dive_model column to activities table.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-03-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "004"
+down_revision = "003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.add_column(sa.Column("deep_dive_model", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.drop_column("deep_dive_model")

--- a/strides_ai/analysis.py
+++ b/strides_ai/analysis.py
@@ -516,4 +516,10 @@ def condense_streams_for_deep_dive(
 
         lines.append(f"{elapsed:>8} | {pace_str:>9} | {hr_str:>5} | {cad_str:>5} | {alt_str:>7}")
 
-    return "\n".join(lines)
+    text = "\n".join(lines)
+
+    notes = activity.get("user_notes", "")
+    if notes and notes.strip():
+        text += f"\n\nAthlete notes:\n{notes.strip()}"
+
+    return text

--- a/strides_ai/analysis.py
+++ b/strides_ai/analysis.py
@@ -1,0 +1,519 @@
+"""Run analysis pipeline — stream fetching, metric computation, NL summary, deep-dive."""
+
+import logging
+import statistics
+from datetime import datetime, timezone
+
+import httpx
+
+from . import db
+
+log = logging.getLogger(__name__)
+
+STRAVA_STREAMS_URL = "https://www.strava.com/api/v3/activities/{id}/streams"
+STREAM_KEYS = "time,heartrate,velocity_smooth,cadence,altitude,watts"
+
+DEEP_DIVE_SYSTEM_PROMPT = (
+    "You are analyzing a single training activity in detail. "
+    "Stream data is sampled at 60-second intervals with key inflection points included. "
+    "Analyze: pacing strategy, HR drift, cadence patterns, elevation impact, and fatigue signs. "
+    "Be specific, cite elapsed times, and provide 3-5 actionable coaching notes in 4-6 paragraphs."
+)
+
+
+class RateLimitError(Exception):
+    """Raised when Strava returns HTTP 429."""
+
+
+# ── Stream fetching ───────────────────────────────────────────────────────────
+
+
+def fetch_activity_streams(activity_id: int, access_token: str) -> dict[str, list]:
+    """
+    Fetch time-series streams for an activity from Strava.
+
+    Returns a dict of stream_name -> list of values.
+    Returns {} when the activity has no stream data (404).
+    Raises RateLimitError on HTTP 429.
+    """
+    url = STRAVA_STREAMS_URL.format(id=activity_id)
+    headers = {"Authorization": f"Bearer {access_token}"}
+    params = {"keys": STREAM_KEYS, "key_by_type": "true"}
+
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(url, headers=headers, params=params)
+    except Exception as exc:
+        log.warning("stream fetch error for activity %s: %s", activity_id, exc)
+        return {}
+
+    if resp.status_code == 429:
+        raise RateLimitError(f"Rate limited fetching streams for activity {activity_id}")
+
+    if resp.status_code == 404:
+        return {}
+
+    if resp.status_code != 200:
+        log.warning("stream fetch HTTP %s for activity %s", resp.status_code, activity_id)
+        return {}
+
+    raw = resp.json()
+    # Strava returns key_by_type as a dict of stream_name -> {data: [...], ...}
+    return {name: stream_obj["data"] for name, stream_obj in raw.items()}
+
+
+# ── Metric helpers ────────────────────────────────────────────────────────────
+
+
+def _cardiac_decoupling(hr: list, velocity: list) -> float | None:
+    """
+    Cardiac decoupling = ((second-half HR/velocity ratio - first-half ratio) / first-half ratio) * 100.
+    Filters out samples where velocity < 0.5 m/s (stops/walking).
+    """
+    try:
+        if not hr or not velocity or len(hr) != len(velocity):
+            return None
+
+        # Filter moving samples
+        pairs = [(h, v) for h, v in zip(hr, velocity) if v is not None and v >= 0.5 and h]
+        if len(pairs) < 10:
+            return None
+
+        mid = len(pairs) // 2
+        first_half = pairs[:mid]
+        second_half = pairs[mid:]
+
+        ratio1 = statistics.mean(h / v for h, v in first_half)
+        ratio2 = statistics.mean(h / v for h, v in second_half)
+
+        if ratio1 == 0:
+            return None
+
+        return ((ratio2 - ratio1) / ratio1) * 100
+    except Exception:
+        return None
+
+
+def _hr_zones(hr: list, max_hr: int) -> dict[str, float] | None:
+    """
+    Compute HR zone distribution as percentages.
+    Zones: Z1 <60%, Z2 60-70%, Z3 70-80%, Z4 80-90%, Z5 >90% of max_hr.
+    """
+    try:
+        valid = [h for h in hr if h and h > 0]
+        if not valid:
+            return None
+
+        total = len(valid)
+        counts = [0, 0, 0, 0, 0]
+
+        for h in valid:
+            pct = h / max_hr
+            if pct < 0.60:
+                counts[0] += 1
+            elif pct < 0.70:
+                counts[1] += 1
+            elif pct < 0.80:
+                counts[2] += 1
+            elif pct < 0.90:
+                counts[3] += 1
+            else:
+                counts[4] += 1
+
+        return {
+            "hr_zone_1_pct": round(counts[0] / total * 100, 2),
+            "hr_zone_2_pct": round(counts[1] / total * 100, 2),
+            "hr_zone_3_pct": round(counts[2] / total * 100, 2),
+            "hr_zone_4_pct": round(counts[3] / total * 100, 2),
+            "hr_zone_5_pct": round(counts[4] / total * 100, 2),
+        }
+    except Exception:
+        return None
+
+
+def _pace_fade_seconds(velocity: list) -> float | None:
+    """
+    Pace fade = last-third avg pace (s/mile) minus first-third avg pace (s/mile).
+    Positive = slowing, negative = negative split.
+    Filters near-zero velocity (< 0.5 m/s).
+    """
+    try:
+        moving = [v for v in velocity if v is not None and v >= 0.5]
+        if len(moving) < 9:
+            return None
+
+        third = len(moving) // 3
+        first_third = moving[:third]
+        last_third = moving[-third:]
+
+        METERS_PER_MILE = 1609.34
+
+        def avg_pace_s_per_mile(velocities: list) -> float:
+            return statistics.mean(METERS_PER_MILE / v for v in velocities)
+
+        return round(avg_pace_s_per_mile(last_third) - avg_pace_s_per_mile(first_third), 2)
+    except Exception:
+        return None
+
+
+def _cadence_stats(cadence: list, is_run: bool) -> tuple[float | None, float | None]:
+    """
+    Compute mean and std dev of cadence.
+    Doubles raw values for runs (Strava sends half-cadence for running).
+    """
+    try:
+        multiplier = 2 if is_run else 1
+        valid = [c * multiplier for c in cadence if c and c > 0]
+        if not valid:
+            return None, None
+        mean = round(statistics.mean(valid), 2)
+        std = round(statistics.stdev(valid), 2) if len(valid) >= 2 else None
+        return mean, std
+    except Exception:
+        return None, None
+
+
+def _effort_efficiency_raw(avg_pace_s_per_km: float | None, avg_hr: float | None) -> float | None:
+    """
+    Raw efficiency = avg_pace_s_per_km / avg_hr.
+    Lower = more efficient (faster pace at lower HR).
+    """
+    try:
+        if avg_pace_s_per_km is None or avg_hr is None or avg_hr <= 0:
+            return None
+        return round(avg_pace_s_per_km / avg_hr, 4)
+    except Exception:
+        return None
+
+
+def _elevation_metrics(altitude: list, distance_m: float) -> tuple[float | None, int | None]:
+    """
+    Compute elevation gain per mile (ft/mile) and high-elevation flag.
+    Elevation gain = sum of positive altitude deltas.
+    """
+    try:
+        if not altitude or distance_m <= 0:
+            return None, None
+
+        gain_m = sum(max(0, altitude[i] - altitude[i - 1]) for i in range(1, len(altitude)))
+        gain_ft = gain_m * 3.28084
+        distance_miles = distance_m / 1609.34
+        per_mile = round(gain_ft / distance_miles, 2)
+        flag = 1 if per_mile > 100 else 0
+        return per_mile, flag
+    except Exception:
+        return None, None
+
+
+def _suffer_mismatch(
+    suffer_score: int | None, z4_pct: float | None, z5_pct: float | None
+) -> int | None:
+    """
+    Flag potential HR data unreliability by comparing suffer score to Z4+Z5 time.
+    """
+    try:
+        if suffer_score is None or z4_pct is None or z5_pct is None:
+            return None
+        high_intensity_pct = (z4_pct + z5_pct) / 100
+        if suffer_score > 50 and high_intensity_pct < 0.15:
+            return 1
+        if suffer_score < 20 and high_intensity_pct > 0.30:
+            return 1
+        return 0
+    except Exception:
+        return None
+
+
+# ── Metric computation ────────────────────────────────────────────────────────
+
+
+def compute_metrics(streams: dict[str, list], activity: dict, max_hr: int = 190) -> dict:
+    """
+    Compute all derived metrics from stream data and the stored activity record.
+    Returns a dict of column_name -> value ready for db.save_analysis().
+    Each metric is computed independently; failures return None for that metric.
+    """
+    hr = streams.get("heartrate")
+    velocity = streams.get("velocity_smooth")
+    cadence = streams.get("cadence")
+    altitude = streams.get("altitude")
+
+    sport_type = activity.get("sport_type", "")
+    is_run = sport_type in db.RUN_TYPES
+    distance_m = activity.get("distance_m") or 0
+
+    metrics: dict = {}
+
+    # Cardiac decoupling
+    metrics["cardiac_decoupling_pct"] = (
+        _cardiac_decoupling(hr, velocity) if hr and velocity else None
+    )
+
+    # HR zones
+    zones = _hr_zones(hr, max_hr) if hr else None
+    if zones:
+        metrics.update(zones)
+    else:
+        for z in range(1, 6):
+            metrics[f"hr_zone_{z}_pct"] = None
+
+    # Pace fade
+    metrics["pace_fade_seconds"] = _pace_fade_seconds(velocity) if velocity else None
+
+    # Cadence stats — note: key "avg_cadence" maps to existing DB column
+    cadence_mean, cadence_std = _cadence_stats(cadence, is_run) if cadence else (None, None)
+    metrics["avg_cadence"] = cadence_mean
+    metrics["cadence_std_dev"] = cadence_std
+
+    # Effort efficiency (uses stored values from activity record)
+    metrics["effort_efficiency_raw"] = _effort_efficiency_raw(
+        activity.get("avg_pace_s_per_km"), activity.get("avg_hr")
+    )
+
+    # Elevation
+    elev_per_mile, elev_flag = (
+        _elevation_metrics(altitude, distance_m) if altitude and distance_m else (None, None)
+    )
+    metrics["elevation_per_mile"] = elev_per_mile
+    metrics["high_elevation_flag"] = elev_flag
+
+    # Suffer score mismatch
+    metrics["suffer_score_mismatch_flag"] = _suffer_mismatch(
+        activity.get("suffer_score"),
+        metrics.get("hr_zone_4_pct"),
+        metrics.get("hr_zone_5_pct"),
+    )
+
+    return metrics
+
+
+# ── Natural language summary ──────────────────────────────────────────────────
+
+
+def build_analysis_summary(metrics: dict) -> str:
+    """
+    Generate a rule-based 1-3 sentence natural language summary of a run.
+    Does not call any LLM.
+    """
+    parts = []
+
+    # Lead with cardiac decoupling
+    cd = metrics.get("cardiac_decoupling_pct")
+    if cd is not None:
+        if cd < 5:
+            parts.append(f"Strong aerobic run — {cd:.1f}% cardiac decoupling.")
+        elif cd < 10:
+            parts.append(f"Moderate aerobic stress — {cd:.1f}% cardiac decoupling.")
+        else:
+            parts.append(f"High cardiac stress — {cd:.1f}% cardiac decoupling.")
+    else:
+        parts.append("Analysis limited — HR/velocity data unavailable.")
+
+    # HR zone distribution
+    z1 = metrics.get("hr_zone_1_pct")
+    z2 = metrics.get("hr_zone_2_pct")
+    z4 = metrics.get("hr_zone_4_pct")
+    z5 = metrics.get("hr_zone_5_pct")
+
+    if z1 is not None and z2 is not None:
+        z12 = z1 + z2
+        zones_available = [
+            (1, z1),
+            (2, z2),
+            (3, metrics.get("hr_zone_3_pct") or 0),
+            (4, z4 or 0),
+            (5, z5 or 0),
+        ]
+        dominant = max(zones_available, key=lambda x: x[1])
+        zone_msg = f"{z12:.0f}% time in Z1/Z2"
+        if z4 is not None and z5 is not None and z4 + z5 > 30:
+            zone_msg += f", {z4 + z5:.0f}% in Z4/Z5 (high intensity)"
+        elif dominant[0] >= 3:
+            zone_msg = f"Dominant effort Z{dominant[0]} ({dominant[1]:.0f}%)"
+        parts.append(zone_msg + ".")
+
+    # Pace fade
+    pf = metrics.get("pace_fade_seconds")
+    if pf is not None and abs(pf) > 15:
+        if pf > 0:
+            parts.append(f"Positive pace fade of {pf:.0f}s/mile in final third.")
+        else:
+            parts.append(f"Negative split — improved {abs(pf):.0f}s/mile in final third.")
+
+    # Elevation
+    if metrics.get("high_elevation_flag"):
+        elev = metrics.get("elevation_per_mile")
+        if elev is not None:
+            parts.append(f"Hilly course ({elev:.0f} ft/mile elevation gain).")
+
+    # Suffer score mismatch
+    if metrics.get("suffer_score_mismatch_flag"):
+        parts.append("Note: HR data may be unreliable for this run.")
+
+    return " ".join(parts)
+
+
+# ── Top-level orchestrator ────────────────────────────────────────────────────
+
+
+def analyze_activity(activity: dict, access_token: str, max_hr: int = 190) -> str:
+    """
+    Fetch streams, compute metrics, generate summary, and persist to the DB.
+
+    Returns:
+        'done'    — analysis completed successfully
+        'pending' — Strava rate limit hit; activity marked for retry
+        'skipped' — no stream data available (manual entry)
+        'error'   — unexpected failure
+    """
+    activity_id = activity["id"]
+
+    try:
+        streams = fetch_activity_streams(activity_id, access_token)
+    except RateLimitError:
+        log.warning("rate limited — marking activity %s as pending", activity_id)
+        db.save_analysis(activity_id, {"analysis_status": "pending"})
+        return "pending"
+    except Exception as exc:
+        log.error("stream fetch failed for activity %s: %s", activity_id, exc)
+        db.save_analysis(activity_id, {"analysis_status": "error"})
+        return "error"
+
+    if not streams:
+        db.save_analysis(
+            activity_id,
+            {
+                "analysis_status": "skipped",
+                "analysis_summary": "Manual activity — no stream data available.",
+            },
+        )
+        return "skipped"
+
+    try:
+        metrics = compute_metrics(streams, activity, max_hr=max_hr)
+        summary = build_analysis_summary(metrics)
+        metrics["analysis_summary"] = summary
+        metrics["analysis_status"] = "done"
+
+        # Remove None values so we don't overwrite existing data with NULL
+        metrics = {k: v for k, v in metrics.items() if v is not None}
+
+        db.save_analysis(activity_id, metrics)
+        db.renormalize_effort_efficiency()
+
+        computed = [
+            k
+            for k, v in metrics.items()
+            if v is not None and k not in ("analysis_status", "analysis_summary")
+        ]
+        log.info("activity %s analyzed — %d metrics computed", activity_id, len(computed))
+        return "done"
+
+    except Exception as exc:
+        log.error("analysis failed for activity %s: %s", activity_id, exc, exc_info=True)
+        db.save_analysis(activity_id, {"analysis_status": "error"})
+        return "error"
+
+
+# ── Deep-dive stream condensation ─────────────────────────────────────────────
+
+
+def condense_streams_for_deep_dive(
+    streams: dict[str, list], activity: dict, interval_s: int = 60
+) -> str:
+    """
+    Format stream data as a compact text table for LLM deep-dive analysis.
+    Downsamples to ~60s intervals plus inflection points where any metric
+    changes by > 10% within a 2-minute window.
+    Targets < 2000 tokens for Ollama compatibility.
+    """
+    time_stream = streams.get("time", [])
+    hr_stream = streams.get("heartrate", [])
+    velocity_stream = streams.get("velocity_smooth", [])
+    cadence_stream = streams.get("cadence", [])
+    altitude_stream = streams.get("altitude", [])
+
+    n = len(time_stream)
+    if n == 0:
+        return "No stream data available."
+
+    METERS_PER_MILE = 1609.34
+    sport_type = activity.get("sport_type", "")
+    is_run = sport_type in db.RUN_TYPES
+
+    def safe_get(lst: list, i: int):
+        return lst[i] if lst and i < len(lst) else None
+
+    def fmt_pace(v):
+        if v is None or v <= 0:
+            return "—"
+        pace_s = METERS_PER_MILE / v
+        m, s = divmod(int(pace_s), 60)
+        return f"{m}:{s:02d}/mi"
+
+    def fmt_speed(v):
+        if v is None or v <= 0:
+            return "—"
+        return f"{v * 3.6:.1f}km/h"
+
+    def fmt_cadence(c):
+        if c is None:
+            return "—"
+        val = c * 2 if is_run else c
+        return str(int(val))
+
+    # Build row indices: always include 60s-interval samples
+    sample_indices = set()
+    last_t = -interval_s
+    for i, t in enumerate(time_stream):
+        if t - last_t >= interval_s:
+            sample_indices.add(i)
+            last_t = t
+
+    # Add inflection points — indices where HR or pace changes > 10% over 2-min window
+    window = 120  # seconds
+    for i in range(n):
+        t_i = time_stream[i]
+        # Find index ~2 minutes earlier
+        j = i
+        while j > 0 and time_stream[j] > t_i - window:
+            j -= 1
+
+        hr_i = safe_get(hr_stream, i)
+        hr_j = safe_get(hr_stream, j)
+        v_i = safe_get(velocity_stream, i)
+        v_j = safe_get(velocity_stream, j)
+
+        if hr_i and hr_j and hr_j > 0 and abs(hr_i - hr_j) / hr_j > 0.10:
+            sample_indices.add(i)
+        if v_i and v_j and v_j > 0 and abs(v_i - v_j) / v_j > 0.10:
+            sample_indices.add(i)
+
+    rows = sorted(sample_indices)
+
+    # Build header
+    pace_col = "PACE" if is_run else "SPEED"
+    lines = [
+        f"Activity: {activity.get('name', 'Unknown')} | {activity.get('date', '')} | "
+        f"Distance: {(activity.get('distance_m') or 0) / 1609.34:.2f} mi",
+        "",
+        f"{'ELAPSED':>8} | {pace_col:>9} | {'HR':>5} | {'CAD':>5} | {'ALT(m)':>7}",
+        "-" * 46,
+    ]
+
+    for i in rows:
+        t = time_stream[i]
+        elapsed = f"{t // 3600:02d}:{(t % 3600) // 60:02d}:{t % 60:02d}"
+        v = safe_get(velocity_stream, i)
+        hr = safe_get(hr_stream, i)
+        cad = safe_get(cadence_stream, i)
+        alt = safe_get(altitude_stream, i)
+
+        pace_str = fmt_pace(v) if is_run else fmt_speed(v)
+        hr_str = str(int(hr)) if hr else "—"
+        cad_str = fmt_cadence(cad)
+        alt_str = f"{alt:.0f}" if alt is not None else "—"
+
+        lines.append(f"{elapsed:>8} | {pace_str:>9} | {hr_str:>5} | {cad_str:>5} | {alt_str:>7}")
+
+    return "\n".join(lines)

--- a/strides_ai/api/app.py
+++ b/strides_ai/api/app.py
@@ -11,6 +11,7 @@ from ..config import UPLOADS_DIR, get_settings
 from .deps import init_backend
 from .routers import (
     activities,
+    analysis,
     calendar,
     charts,
     chat,
@@ -51,5 +52,6 @@ app.include_router(memories.router, prefix="/api")
 app.include_router(profile.router, prefix="/api")
 app.include_router(sync.router, prefix="/api")
 app.include_router(history.router, prefix="/api")
+app.include_router(analysis.router, prefix="/api")
 app.include_router(calendar.router, prefix="/api")
 app.include_router(status.router, prefix="/api")

--- a/strides_ai/api/routers/analysis.py
+++ b/strides_ai/api/routers/analysis.py
@@ -30,6 +30,18 @@ class DeepDiveResponse(BaseModel):
     completed_at: str | None
 
 
+class NotesRequest(BaseModel):
+    notes: str
+
+
+@router.patch("/activities/{activity_id}/notes", status_code=204)
+async def save_notes(activity_id: int, body: NotesRequest) -> None:
+    """Persist user-authored notes for an activity."""
+    if db.get_activity(activity_id) is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    db.save_analysis(activity_id, {"user_notes": body.notes})
+
+
 @router.post("/activities/{activity_id}/deep-dive", response_model=DeepDiveResponse)
 async def deep_dive(
     activity_id: int,

--- a/strides_ai/api/routers/analysis.py
+++ b/strides_ai/api/routers/analysis.py
@@ -16,6 +16,7 @@ from ...analysis import (
     fetch_activity_streams,
 )
 from ...auth import get_access_token
+from ...config import get_settings
 from ..deps import get_backend
 
 router = APIRouter()
@@ -55,8 +56,11 @@ async def deep_dive(
         )
 
     # Fetch streams
+    settings = get_settings()
+    if not settings.strava_client_id or not settings.strava_client_secret:
+        raise HTTPException(status_code=500, detail="Strava credentials not configured")
     try:
-        access_token = get_access_token()
+        access_token = get_access_token(settings.strava_client_id, settings.strava_client_secret)
     except Exception as exc:
         raise HTTPException(status_code=503, detail=f"Could not get Strava token: {exc}")
 

--- a/strides_ai/api/routers/analysis.py
+++ b/strides_ai/api/routers/analysis.py
@@ -1,0 +1,106 @@
+"""Deep-dive analysis endpoint."""
+
+import asyncio
+import functools
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from ... import db
+from ...analysis import (
+    DEEP_DIVE_SYSTEM_PROMPT,
+    RateLimitError,
+    condense_streams_for_deep_dive,
+    fetch_activity_streams,
+)
+from ...auth import get_access_token
+from ..deps import get_backend
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+
+class DeepDiveResponse(BaseModel):
+    activity_id: int
+    report: str
+    cached: bool
+    completed_at: str | None
+
+
+@router.post("/activities/{activity_id}/deep-dive", response_model=DeepDiveResponse)
+async def deep_dive(
+    activity_id: int,
+    request: Request,
+    force: bool = False,
+    backend=Depends(get_backend),
+) -> DeepDiveResponse:
+    """
+    Generate (or return cached) a deep-dive LLM analysis for a single activity.
+
+    Set force=true to regenerate even if a cached report exists.
+    """
+    activity = db.get_activity(activity_id)
+    if activity is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Return cached report unless force=true
+    if activity.get("deep_dive_report") and not force:
+        return DeepDiveResponse(
+            activity_id=activity_id,
+            report=activity["deep_dive_report"],
+            cached=True,
+            completed_at=activity.get("deep_dive_completed_at"),
+        )
+
+    # Fetch streams
+    try:
+        access_token = get_access_token()
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Could not get Strava token: {exc}")
+
+    try:
+        streams = fetch_activity_streams(activity_id, access_token)
+    except RateLimitError:
+        raise HTTPException(status_code=429, detail="Strava rate limit reached — try again shortly")
+    except Exception as exc:
+        log.error("stream fetch error for deep dive %s: %s", activity_id, exc)
+        raise HTTPException(status_code=502, detail="Failed to fetch stream data from Strava")
+
+    if not streams:
+        raise HTTPException(
+            status_code=422,
+            detail="No stream data available for this activity (manual entry or GPS disabled)",
+        )
+
+    # Build condensed stream representation
+    condensed = condense_streams_for_deep_dive(streams, activity)
+
+    # Run the (sync) LLM call in a thread pool so we don't block the event loop
+    def _run_llm():
+        text, _ = backend.stream_turn(
+            DEEP_DIVE_SYSTEM_PROMPT,
+            condensed,
+            on_token=lambda _: None,
+        )
+        return text
+
+    try:
+        report = await asyncio.get_event_loop().run_in_executor(None, _run_llm)
+    except Exception as exc:
+        log.error("LLM deep dive failed for activity %s: %s", activity_id, exc)
+        raise HTTPException(status_code=500, detail="LLM analysis failed")
+
+    completed_at = datetime.now(timezone.utc).isoformat()
+    db.save_analysis(
+        activity_id,
+        {"deep_dive_report": report, "deep_dive_completed_at": completed_at},
+    )
+
+    return DeepDiveResponse(
+        activity_id=activity_id,
+        report=report,
+        cached=False,
+        completed_at=completed_at,
+    )

--- a/strides_ai/api/routers/analysis.py
+++ b/strides_ai/api/routers/analysis.py
@@ -28,6 +28,7 @@ class DeepDiveResponse(BaseModel):
     report: str
     cached: bool
     completed_at: str | None
+    model: str | None = None
 
 
 class NotesRequest(BaseModel):
@@ -65,6 +66,7 @@ async def deep_dive(
             report=activity["deep_dive_report"],
             cached=True,
             completed_at=activity.get("deep_dive_completed_at"),
+            model=activity.get("deep_dive_model"),
         )
 
     # Fetch streams
@@ -109,9 +111,14 @@ async def deep_dive(
         raise HTTPException(status_code=500, detail="LLM analysis failed")
 
     completed_at = datetime.now(timezone.utc).isoformat()
+    model_label = backend.label
     db.save_analysis(
         activity_id,
-        {"deep_dive_report": report, "deep_dive_completed_at": completed_at},
+        {
+            "deep_dive_report": report,
+            "deep_dive_completed_at": completed_at,
+            "deep_dive_model": model_label,
+        },
     )
 
     return DeepDiveResponse(
@@ -119,4 +126,5 @@ async def deep_dive(
         report=report,
         cached=False,
         completed_at=completed_at,
+        model=model_label,
     )

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -132,6 +132,24 @@ def build_system(
     # Pin only the most recent activities every turn (cheap, always survives truncation).
     # The full training log is seeded once in conversation history.
     recent = (activities or [])[:RECENT_ACTIVITIES_IN_SYSTEM]
+
+    # Inject metrics guide when any activity has been analyzed
+    has_analysis = any(a.get("analysis_summary") for a in recent)
+    if has_analysis:
+        prompt += (
+            "\n\n## Analysis Metrics Guide\n"
+            "The ANALYSIS column in the training log contains auto-generated summaries. "
+            "Key metrics to reason about:\n"
+            "- **Cardiac decoupling %**: aerobic efficiency; <5% = well-coupled (good), "
+            "5–10% = moderate stress, >10% = high cardiovascular drift\n"
+            "- **Effort efficiency score**: 0–100, normalized vs athlete's full history; "
+            "higher = more efficient pace for a given HR\n"
+            "- **HR zones**: Z1=recovery, Z2=aerobic base, Z3=tempo, "
+            "Z4=threshold, Z5=VO2max/max effort\n"
+            "- **Pace fade**: sec/mile change in final third vs first third; "
+            "positive = slowing (possible fatigue), negative = negative split"
+        )
+
     recent_log = build_training_log(recent, mode)
     prompt += (
         f"\n\n## Recent Activities (last {RECENT_ACTIVITIES_IN_SYSTEM})\n\n```\n{recent_log}\n```"
@@ -170,14 +188,14 @@ def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
         return "No activities found."
 
     if mode == "hybrid":
-        header = "DATE       | TYPE       | NAME                           | DIST(km) | DURATION | PACE/SPEED  | AVG HR | MAX HR | CADENCE | ELEV(m) | SUFFER | RPE"
-        sep = "-" * 150
+        header = "DATE       | TYPE       | NAME                           | DIST(km) | DURATION | PACE/SPEED  | AVG HR | MAX HR | CADENCE | ELEV(m) | SUFFER | RPE | ANALYSIS"
+        sep = "-" * 215
     elif mode == "cycling":
-        header = "DATE       | NAME                           | DIST(km) | DURATION | SPEED    | AVG HR | MAX HR | CADENCE(rpm) | ELEV(m) | SUFFER | RPE"
-        sep = "-" * 135
+        header = "DATE       | NAME                           | DIST(km) | DURATION | SPEED    | AVG HR | MAX HR | CADENCE(rpm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
+        sep = "-" * 200
     else:
-        header = "DATE       | NAME                           | DIST(km) | DURATION | PACE     | AVG HR | MAX HR | CADENCE(spm) | ELEV(m) | SUFFER | RPE"
-        sep = "-" * 135
+        header = "DATE       | NAME                           | DIST(km) | DURATION | PACE     | AVG HR | MAX HR | CADENCE(spm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
+        sep = "-" * 200
 
     lines = [header, sep]
 
@@ -185,6 +203,8 @@ def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
         dist_km = (r["distance_m"] or 0) / 1000
         sport = r["sport_type"] or ""
         is_run = sport in RUN_TYPES
+
+        analysis = (r.get("analysis_summary") or "")[:60]
 
         if mode == "hybrid":
             pace_speed = (
@@ -204,7 +224,8 @@ def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
                 f"{r['avg_cadence'] or '—':7} | "
                 f"{r['elevation_gain_m'] or '—':7} | "
                 f"{r['suffer_score'] or '—':6} | "
-                f"{r['perceived_exertion'] or '—'}"
+                f"{r['perceived_exertion'] or '—':3} | "
+                f"{analysis}"
             )
         elif mode == "cycling":
             lines.append(
@@ -218,7 +239,8 @@ def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
                 f"{r['avg_cadence'] or '—':12} | "
                 f"{r['elevation_gain_m'] or '—':7} | "
                 f"{r['suffer_score'] or '—':6} | "
-                f"{r['perceived_exertion'] or '—'}"
+                f"{r['perceived_exertion'] or '—':3} | "
+                f"{analysis}"
             )
         else:  # running
             lines.append(
@@ -232,7 +254,8 @@ def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
                 f"{r['avg_cadence'] or '—':12} | "
                 f"{r['elevation_gain_m'] or '—':7} | "
                 f"{r['suffer_score'] or '—':6} | "
-                f"{r['perceived_exertion'] or '—'}"
+                f"{r['perceived_exertion'] or '—':3} | "
+                f"{analysis}"
             )
 
     total_km = sum((r["distance_m"] or 0) / 1000 for r in rows)

--- a/strides_ai/db.py
+++ b/strides_ai/db.py
@@ -55,6 +55,7 @@ class Activity(SQLModel, table=True):
     analysis_summary: Optional[str] = None
     deep_dive_report: Optional[str] = None
     deep_dive_completed_at: Optional[str] = None
+    deep_dive_model: Optional[str] = None
     analysis_status: Optional[str] = None
     user_notes: Optional[str] = None
 

--- a/strides_ai/db.py
+++ b/strides_ai/db.py
@@ -38,6 +38,25 @@ class Activity(SQLModel, table=True):
     sport_type: Optional[str] = None
     raw_json: Optional[str] = None
 
+    # Analysis columns (populated by analysis pipeline)
+    cardiac_decoupling_pct: Optional[float] = None
+    hr_zone_1_pct: Optional[float] = None
+    hr_zone_2_pct: Optional[float] = None
+    hr_zone_3_pct: Optional[float] = None
+    hr_zone_4_pct: Optional[float] = None
+    hr_zone_5_pct: Optional[float] = None
+    pace_fade_seconds: Optional[float] = None
+    cadence_std_dev: Optional[float] = None
+    effort_efficiency_raw: Optional[float] = None
+    effort_efficiency_score: Optional[float] = None
+    elevation_per_mile: Optional[float] = None
+    high_elevation_flag: Optional[int] = None
+    suffer_score_mismatch_flag: Optional[int] = None
+    analysis_summary: Optional[str] = None
+    deep_dive_report: Optional[str] = None
+    deep_dive_completed_at: Optional[str] = None
+    analysis_status: Optional[str] = None
+
 
 class Conversation(SQLModel, table=True):
     __tablename__ = "conversations"
@@ -270,6 +289,81 @@ def get_activities_for_mode(mode: str) -> list[dict]:
             stmt = select(Activity).order_by(Activity.date.desc())
         rows = session.exec(stmt).all()
     return [r.model_dump() for r in rows]
+
+
+def get_activity(activity_id: int) -> dict | None:
+    """Return a single activity by ID, or None if not found."""
+    with Session(_get_engine()) as session:
+        row = session.get(Activity, activity_id)
+    return row.model_dump() if row else None
+
+
+def save_analysis(activity_id: int, metrics: dict) -> None:
+    """Write computed analysis columns back to a single activity row."""
+    if not metrics:
+        return
+    with _get_engine().connect() as conn:
+        cols = ", ".join(f"{k} = :{k}" for k in metrics)
+        stmt = sa.text(f"UPDATE activities SET {cols} WHERE id = :_id")
+        conn.execute(stmt, {**metrics, "_id": activity_id})
+        conn.commit()
+
+
+def get_activities_pending_analysis(limit: int = 10) -> list[dict]:
+    """Return up to *limit* activities where analysis_status is 'pending' or NULL."""
+    with Session(_get_engine()) as session:
+        stmt = (
+            select(Activity)
+            .where(
+                sa.or_(
+                    Activity.analysis_status == "pending",
+                    Activity.analysis_status.is_(None),
+                )
+            )
+            .order_by(Activity.date.desc())
+            .limit(limit)
+        )
+        rows = session.exec(stmt).all()
+    return [r.model_dump() for r in rows]
+
+
+def renormalize_effort_efficiency() -> None:
+    """
+    Re-score effort_efficiency_score for all rows using inverted min-max normalization.
+    Lower raw ratio (faster pace / lower HR) = more efficient = higher score.
+    Formula: score = 100 * (max_raw - raw) / (max_raw - min_raw)
+    """
+    with _get_engine().connect() as conn:
+        result = conn.execute(
+            sa.text(
+                "SELECT MIN(effort_efficiency_raw), MAX(effort_efficiency_raw)"
+                " FROM activities WHERE effort_efficiency_raw IS NOT NULL"
+            )
+        ).one()
+        min_raw, max_raw = result
+
+        if min_raw is None:
+            return
+
+        if min_raw == max_raw:
+            conn.execute(
+                sa.text(
+                    "UPDATE activities SET effort_efficiency_score = 50.0"
+                    " WHERE effort_efficiency_raw IS NOT NULL"
+                )
+            )
+        else:
+            conn.execute(
+                sa.text(
+                    "UPDATE activities"
+                    " SET effort_efficiency_score = ROUND("
+                    "   100.0 * (:max_raw - effort_efficiency_raw) / (:max_raw - :min_raw), 2"
+                    " )"
+                    " WHERE effort_efficiency_raw IS NOT NULL"
+                ),
+                {"min_raw": min_raw, "max_raw": max_raw},
+            )
+        conn.commit()
 
 
 # ── Profiles ─────────────────────────────────────────────────────────────────

--- a/strides_ai/db.py
+++ b/strides_ai/db.py
@@ -56,6 +56,7 @@ class Activity(SQLModel, table=True):
     deep_dive_report: Optional[str] = None
     deep_dive_completed_at: Optional[str] = None
     analysis_status: Optional[str] = None
+    user_notes: Optional[str] = None
 
 
 class Conversation(SQLModel, table=True):

--- a/strides_ai/sync.py
+++ b/strides_ai/sync.py
@@ -1,14 +1,19 @@
 """Fetch runs and rides from Strava and persist them locally."""
 
+import logging
 from typing import Generator
 
 import httpx
 
+from . import db
+from .analysis import RateLimitError, analyze_activity
 from .db import get_stored_ids, upsert_activity, RUN_TYPES, CYCLE_TYPES
 
 ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"
 ALL_SYNCED_TYPES = RUN_TYPES | CYCLE_TYPES
 PAGE_SIZE = 100
+
+log = logging.getLogger(__name__)
 
 
 def _iter_activities(access_token: str) -> Generator[dict, None, None]:
@@ -45,7 +50,9 @@ def sync_activities(access_token: str, full: bool = False) -> int:
     Returns the number of new/updated activities written.
     """
     stored_ids = get_stored_ids()
+    max_hr = int(db.get_setting("max_hr", "190") or "190")
     count = 0
+    rate_limited = False
 
     for activity in _iter_activities(access_token):
         sport = activity.get("sport_type") or activity.get("type", "")
@@ -58,5 +65,26 @@ def sync_activities(access_token: str, full: bool = False) -> int:
 
         upsert_activity(activity)
         count += 1
+
+        # Skip analysis for already-analyzed activities during a full sync
+        if full and activity["id"] in stored_ids:
+            stored = db.get_activity(activity["id"])
+            if stored and stored.get("analysis_status") == "done":
+                continue
+
+        if not rate_limited:
+            status = analyze_activity(activity, access_token, max_hr=max_hr)
+            if status == "pending":
+                log.warning("rate limited during sync — deferring remaining stream fetches")
+                rate_limited = True
+
+    # Backfill: process up to 10 pending/unanalyzed activities per sync cycle
+    if not rate_limited:
+        pending = db.get_activities_pending_analysis(limit=10)
+        for act in pending:
+            status = analyze_activity(act, access_token, max_hr=max_hr)
+            if status == "pending":
+                log.warning("rate limited during backfill — stopping")
+                break
 
     return count

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,634 @@
+"""Unit tests for strides_ai.analysis — metric computation, NL summary, DB helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strides_ai.analysis import (
+    RateLimitError,
+    _cadence_stats,
+    _cardiac_decoupling,
+    _effort_efficiency_raw,
+    _elevation_metrics,
+    _hr_zones,
+    _pace_fade_seconds,
+    _suffer_mismatch,
+    build_analysis_summary,
+    compute_metrics,
+    condense_streams_for_deep_dive,
+    fetch_activity_streams,
+)
+from strides_ai import db
+
+
+# ── _cardiac_decoupling ───────────────────────────────────────────────────────
+
+
+def test_cardiac_decoupling_basic():
+    # First half HR/velocity = 150/3 = 50, second half = 165/3 = 55
+    # decoupling = (55 - 50) / 50 * 100 = 10%
+    hr = [150] * 50 + [165] * 50
+    vel = [3.0] * 100
+    result = _cardiac_decoupling(hr, vel)
+    assert result == pytest.approx(10.0, abs=1.0)
+
+
+def test_cardiac_decoupling_no_drift():
+    hr = [150] * 100
+    vel = [3.0] * 100
+    result = _cardiac_decoupling(hr, vel)
+    assert result == pytest.approx(0.0, abs=0.1)
+
+
+def test_cardiac_decoupling_filters_low_velocity():
+    # Stops are filtered out; 50 moving samples all have same HR/velocity ratio → 0.0
+    hr = [150] * 50 + [165] * 50
+    vel = [0.0] * 50 + [3.0] * 50  # first 50 stopped, second 50 moving
+    result = _cardiac_decoupling(hr, vel)
+    # 50 moving samples with uniform ratio in both halves → 0% decoupling
+    assert result == pytest.approx(0.0, abs=0.1)
+
+
+def test_cardiac_decoupling_mismatched_lengths_returns_none():
+    assert _cardiac_decoupling([150, 160], [3.0]) is None
+
+
+def test_cardiac_decoupling_empty_returns_none():
+    assert _cardiac_decoupling([], []) is None
+
+
+def test_cardiac_decoupling_too_few_samples_returns_none():
+    # Need >= 10 moving samples total
+    hr = [150] * 5
+    vel = [3.0] * 5
+    assert _cardiac_decoupling(hr, vel) is None
+
+
+# ── _hr_zones ─────────────────────────────────────────────────────────────────
+
+
+def test_hr_zones_all_z1(max_hr=190):
+    # 100 bpm = 52.6% of 190 → all Z1
+    hr = [100] * 100
+    zones = _hr_zones(hr, max_hr=190)
+    assert zones is not None
+    assert zones["hr_zone_1_pct"] == pytest.approx(100.0)
+    for z in range(2, 6):
+        assert zones[f"hr_zone_{z}_pct"] == pytest.approx(0.0)
+
+
+def test_hr_zones_all_z5():
+    # 185 bpm = 97.4% of 190 → all Z5
+    hr = [185] * 100
+    zones = _hr_zones(hr, max_hr=190)
+    assert zones is not None
+    assert zones["hr_zone_5_pct"] == pytest.approx(100.0)
+
+
+def test_hr_zones_sums_to_100():
+    hr = [100, 115, 135, 155, 180] * 20  # mix of all zones
+    zones = _hr_zones(hr, max_hr=190)
+    assert zones is not None
+    total = sum(zones.values())
+    assert total == pytest.approx(100.0, abs=0.1)
+
+
+def test_hr_zones_filters_zeros():
+    # Mix of valid HR and zeros — zeros should be ignored
+    hr = [0] * 50 + [150] * 50
+    zones = _hr_zones(hr, max_hr=190)
+    assert zones is not None
+    # 150/190 = 79% → Z3
+    assert zones["hr_zone_3_pct"] == pytest.approx(100.0)
+
+
+def test_hr_zones_all_zeros_returns_none():
+    assert _hr_zones([0, 0, 0], max_hr=190) is None
+
+
+def test_hr_zones_empty_returns_none():
+    assert _hr_zones([], max_hr=190) is None
+
+
+def test_hr_zones_zone_boundaries():
+    max_hr = 190
+    # Exactly at Z2/Z3 boundary: 70% of 190 = 133
+    zones_below = _hr_zones([132], max_hr=max_hr)
+    zones_above = _hr_zones([133], max_hr=max_hr)
+    assert zones_below["hr_zone_2_pct"] == pytest.approx(100.0)
+    assert zones_above["hr_zone_3_pct"] == pytest.approx(100.0)
+
+
+# ── _pace_fade_seconds ────────────────────────────────────────────────────────
+
+
+def test_pace_fade_slowing():
+    # 3 m/s in first third, 2 m/s in last third
+    # pace at 3 m/s = 1609.34/3 ≈ 536.4 s/mile
+    # pace at 2 m/s = 1609.34/2 ≈ 804.7 s/mile
+    # fade ≈ 268 s/mile (positive = slowing)
+    velocity = [3.0] * 30 + [2.5] * 30 + [2.0] * 30
+    result = _pace_fade_seconds(velocity)
+    assert result is not None
+    assert result > 200  # positive = slowing
+
+
+def test_pace_fade_negative_split():
+    velocity = [2.0] * 30 + [2.5] * 30 + [3.0] * 30
+    result = _pace_fade_seconds(velocity)
+    assert result is not None
+    assert result < -100  # negative = faster in final third
+
+
+def test_pace_fade_steady_pace():
+    velocity = [3.0] * 90
+    result = _pace_fade_seconds(velocity)
+    assert result == pytest.approx(0.0, abs=1.0)
+
+
+def test_pace_fade_filters_near_zero():
+    # Stops should be excluded
+    velocity = [0.0] * 10 + [3.0] * 30 + [2.5] * 30 + [2.0] * 30
+    result = _pace_fade_seconds(velocity)
+    assert result is not None
+    assert result > 0
+
+
+def test_pace_fade_too_few_samples_returns_none():
+    assert _pace_fade_seconds([3.0] * 5) is None
+
+
+# ── _cadence_stats ────────────────────────────────────────────────────────────
+
+
+def test_cadence_stats_run_doubles_values():
+    cadence = [90.0] * 10  # raw half-cadence from Strava
+    mean, std = _cadence_stats(cadence, is_run=True)
+    assert mean == pytest.approx(180.0)
+    assert std == pytest.approx(0.0)
+
+
+def test_cadence_stats_cycle_no_doubling():
+    cadence = [85.0] * 10
+    mean, std = _cadence_stats(cadence, is_run=False)
+    assert mean == pytest.approx(85.0)
+
+
+def test_cadence_stats_std_dev():
+    cadence = [80.0, 90.0, 100.0]
+    mean, std = _cadence_stats(cadence, is_run=False)
+    assert mean == pytest.approx(90.0)
+    assert std is not None
+    assert std > 0
+
+
+def test_cadence_stats_single_value_std_is_none():
+    mean, std = _cadence_stats([90.0], is_run=False)
+    assert mean == pytest.approx(90.0)
+    assert std is None
+
+
+def test_cadence_stats_filters_zeros():
+    cadence = [0, 0, 90.0, 90.0]
+    mean, std = _cadence_stats(cadence, is_run=False)
+    assert mean == pytest.approx(90.0)
+
+
+def test_cadence_stats_all_zeros_returns_none():
+    mean, std = _cadence_stats([0, 0, 0], is_run=False)
+    assert mean is None
+    assert std is None
+
+
+# ── _effort_efficiency_raw ────────────────────────────────────────────────────
+
+
+def test_effort_efficiency_raw_basic():
+    # pace 360 s/km, hr 150 → 360/150 = 2.4
+    result = _effort_efficiency_raw(360.0, 150.0)
+    assert result == pytest.approx(2.4)
+
+
+def test_effort_efficiency_raw_none_pace():
+    assert _effort_efficiency_raw(None, 150.0) is None
+
+
+def test_effort_efficiency_raw_none_hr():
+    assert _effort_efficiency_raw(360.0, None) is None
+
+
+def test_effort_efficiency_raw_zero_hr():
+    assert _effort_efficiency_raw(360.0, 0.0) is None
+
+
+def test_effort_efficiency_raw_negative_hr():
+    assert _effort_efficiency_raw(360.0, -10.0) is None
+
+
+# ── _elevation_metrics ────────────────────────────────────────────────────────
+
+
+def test_elevation_metrics_flat():
+    altitude = [100.0] * 100
+    per_mile, flag = _elevation_metrics(altitude, distance_m=10000)
+    assert per_mile == pytest.approx(0.0)
+    assert flag == 0
+
+
+def test_elevation_metrics_hilly():
+    # 200m gain over 10km ≈ 6.2 miles → ~200*3.28/6.2 ≈ 105 ft/mile
+    altitude = [float(i) for i in range(100)] + [100.0] * 100  # 99m gain
+    altitude_hilly = [0.0, 200.0, 200.0, 0.0, 200.0, 200.0]  # 400m gain
+    per_mile, flag = _elevation_metrics(altitude_hilly, distance_m=3218)  # 2 miles
+    assert per_mile is not None
+    assert flag in (0, 1)
+
+
+def test_elevation_metrics_high_elevation_flag():
+    # 200m (656 ft) gain over 1 mile (1609m) = 656 ft/mile → flag
+    altitude = [0.0, 200.0]
+    per_mile, flag = _elevation_metrics(altitude, distance_m=1609.34)
+    assert per_mile is not None
+    assert per_mile > 100
+    assert flag == 1
+
+
+def test_elevation_metrics_low_elevation_no_flag():
+    # 30m (98 ft) gain over 1 mile → no flag
+    altitude = [0.0, 30.0]
+    per_mile, flag = _elevation_metrics(altitude, distance_m=1609.34)
+    assert flag == 0
+
+
+def test_elevation_metrics_no_altitude_returns_none():
+    assert _elevation_metrics([], distance_m=10000) == (None, None)
+
+
+def test_elevation_metrics_zero_distance_returns_none():
+    assert _elevation_metrics([100.0, 110.0], distance_m=0) == (None, None)
+
+
+# ── _suffer_mismatch ──────────────────────────────────────────────────────────
+
+
+def test_suffer_mismatch_high_suffer_low_intensity():
+    # suffer=60, z4+z5=10% → mismatch
+    assert _suffer_mismatch(60, 7.0, 3.0) == 1
+
+
+def test_suffer_mismatch_low_suffer_high_intensity():
+    # suffer=10, z4+z5=35% → mismatch
+    assert _suffer_mismatch(10, 20.0, 15.0) == 1
+
+
+def test_suffer_mismatch_consistent_no_flag():
+    # suffer=70, z4+z5=40% → consistent
+    assert _suffer_mismatch(70, 25.0, 15.0) == 0
+
+
+def test_suffer_mismatch_none_suffer_returns_none():
+    assert _suffer_mismatch(None, 10.0, 5.0) is None
+
+
+def test_suffer_mismatch_none_zones_returns_none():
+    assert _suffer_mismatch(60, None, None) is None
+
+
+# ── build_analysis_summary ────────────────────────────────────────────────────
+
+
+def test_summary_strong_aerobic():
+    metrics = {
+        "cardiac_decoupling_pct": 3.0,
+        "hr_zone_1_pct": 40.0,
+        "hr_zone_2_pct": 45.0,
+        "hr_zone_3_pct": 10.0,
+        "hr_zone_4_pct": 3.0,
+        "hr_zone_5_pct": 2.0,
+        "pace_fade_seconds": 5.0,
+        "high_elevation_flag": 0,
+        "suffer_score_mismatch_flag": 0,
+    }
+    summary = build_analysis_summary(metrics)
+    assert "Strong aerobic" in summary
+    assert "3.0%" in summary
+
+
+def test_summary_high_cardiac_stress():
+    metrics = {
+        "cardiac_decoupling_pct": 14.0,
+        "hr_zone_1_pct": 5.0,
+        "hr_zone_2_pct": 10.0,
+        "hr_zone_3_pct": 15.0,
+        "hr_zone_4_pct": 35.0,
+        "hr_zone_5_pct": 35.0,
+        "pace_fade_seconds": 0.0,
+        "high_elevation_flag": 0,
+        "suffer_score_mismatch_flag": 0,
+    }
+    summary = build_analysis_summary(metrics)
+    assert "High cardiac stress" in summary
+
+
+def test_summary_includes_pace_fade_when_significant():
+    metrics = {
+        "cardiac_decoupling_pct": 5.0,
+        "hr_zone_1_pct": 50.0,
+        "hr_zone_2_pct": 30.0,
+        "hr_zone_3_pct": 10.0,
+        "hr_zone_4_pct": 5.0,
+        "hr_zone_5_pct": 5.0,
+        "pace_fade_seconds": 30.0,
+        "high_elevation_flag": 0,
+        "suffer_score_mismatch_flag": 0,
+    }
+    summary = build_analysis_summary(metrics)
+    assert "30" in summary
+    assert "pace fade" in summary.lower() or "slowed" in summary.lower()
+
+
+def test_summary_ignores_small_pace_fade():
+    metrics = {
+        "cardiac_decoupling_pct": 4.0,
+        "pace_fade_seconds": 5.0,
+        "hr_zone_1_pct": 60.0,
+        "hr_zone_2_pct": 30.0,
+        "hr_zone_3_pct": 5.0,
+        "hr_zone_4_pct": 3.0,
+        "hr_zone_5_pct": 2.0,
+        "high_elevation_flag": 0,
+        "suffer_score_mismatch_flag": 0,
+    }
+    summary = build_analysis_summary(metrics)
+    # pace fade of 5 is insignificant — should not appear
+    assert "fade" not in summary.lower()
+
+
+def test_summary_hilly_course():
+    metrics = {
+        "cardiac_decoupling_pct": 4.0,
+        "hr_zone_1_pct": 40.0,
+        "hr_zone_2_pct": 40.0,
+        "hr_zone_3_pct": 10.0,
+        "hr_zone_4_pct": 5.0,
+        "hr_zone_5_pct": 5.0,
+        "pace_fade_seconds": 0.0,
+        "high_elevation_flag": 1,
+        "elevation_per_mile": 150.0,
+        "suffer_score_mismatch_flag": 0,
+    }
+    summary = build_analysis_summary(metrics)
+    assert "150" in summary or "Hilly" in summary
+
+
+def test_summary_mismatch_warning():
+    metrics = {
+        "cardiac_decoupling_pct": 6.0,
+        "hr_zone_1_pct": 50.0,
+        "hr_zone_2_pct": 30.0,
+        "hr_zone_3_pct": 10.0,
+        "hr_zone_4_pct": 5.0,
+        "hr_zone_5_pct": 5.0,
+        "pace_fade_seconds": 0.0,
+        "high_elevation_flag": 0,
+        "suffer_score_mismatch_flag": 1,
+    }
+    summary = build_analysis_summary(metrics)
+    assert "unreliable" in summary.lower() or "Note" in summary
+
+
+def test_summary_no_cardiac_data():
+    metrics = {
+        "cardiac_decoupling_pct": None,
+        "hr_zone_1_pct": None,
+        "hr_zone_2_pct": None,
+        "hr_zone_3_pct": None,
+        "hr_zone_4_pct": None,
+        "hr_zone_5_pct": None,
+        "pace_fade_seconds": None,
+        "high_elevation_flag": 0,
+        "suffer_score_mismatch_flag": None,
+    }
+    summary = build_analysis_summary(metrics)
+    assert len(summary) > 0  # should not crash
+
+
+# ── compute_metrics ───────────────────────────────────────────────────────────
+
+
+def test_compute_metrics_full_streams():
+    streams = {
+        "time": list(range(0, 600, 1)),
+        "heartrate": [150] * 300 + [165] * 300,
+        "velocity_smooth": [3.0] * 600,
+        "cadence": [90.0] * 600,
+        "altitude": [100.0] * 600,
+    }
+    activity = {
+        "id": 1,
+        "sport_type": "Run",
+        "distance_m": 1800.0,
+        "avg_pace_s_per_km": 360.0,
+        "avg_hr": 157.0,
+        "suffer_score": 40,
+    }
+    metrics = compute_metrics(streams, activity, max_hr=190)
+    assert "cardiac_decoupling_pct" in metrics
+    assert "hr_zone_1_pct" in metrics
+    assert "pace_fade_seconds" in metrics
+    assert "avg_cadence" in metrics  # maps to existing DB column
+    assert "cadence_std_dev" in metrics
+    assert "effort_efficiency_raw" in metrics
+    assert "elevation_per_mile" in metrics
+    assert "high_elevation_flag" in metrics
+
+
+def test_compute_metrics_missing_hr():
+    streams = {
+        "time": list(range(0, 300)),
+        "velocity_smooth": [3.0] * 300,
+    }
+    activity = {
+        "id": 1,
+        "sport_type": "Run",
+        "distance_m": 900.0,
+        "avg_pace_s_per_km": 360.0,
+        "avg_hr": None,
+    }
+    metrics = compute_metrics(streams, activity, max_hr=190)
+    assert metrics["cardiac_decoupling_pct"] is None
+    assert metrics["hr_zone_1_pct"] is None
+
+
+def test_compute_metrics_avg_cadence_key_used_not_cadence_avg():
+    """Ensure the returned key is 'avg_cadence' (existing DB column), not 'cadence_avg'."""
+    streams = {"cadence": [90.0] * 100}
+    activity = {
+        "id": 1,
+        "sport_type": "Run",
+        "distance_m": 1000.0,
+        "avg_pace_s_per_km": 360.0,
+        "avg_hr": 150.0,
+    }
+    metrics = compute_metrics(streams, activity)
+    assert "avg_cadence" in metrics
+    assert "cadence_avg" not in metrics
+
+
+def test_compute_metrics_empty_streams_returns_none_values():
+    activity = {
+        "id": 1,
+        "sport_type": "Run",
+        "distance_m": 0,
+        "avg_pace_s_per_km": None,
+        "avg_hr": None,
+    }
+    metrics = compute_metrics({}, activity)
+    assert metrics["cardiac_decoupling_pct"] is None
+    assert metrics["effort_efficiency_raw"] is None
+
+
+# ── fetch_activity_streams ────────────────────────────────────────────────────
+
+
+def test_fetch_streams_success():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "heartrate": {"data": [150, 155, 160]},
+        "velocity_smooth": {"data": [3.0, 3.1, 2.9]},
+    }
+
+    with patch("strides_ai.analysis.httpx.Client") as MockClient:
+        MockClient.return_value.__enter__.return_value.get.return_value = mock_response
+        result = fetch_activity_streams(12345, "fake_token")
+
+    assert result["heartrate"] == [150, 155, 160]
+    assert result["velocity_smooth"] == [3.0, 3.1, 2.9]
+
+
+def test_fetch_streams_404_returns_empty():
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+
+    with patch("strides_ai.analysis.httpx.Client") as MockClient:
+        MockClient.return_value.__enter__.return_value.get.return_value = mock_response
+        result = fetch_activity_streams(12345, "fake_token")
+
+    assert result == {}
+
+
+def test_fetch_streams_429_raises_rate_limit_error():
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+
+    with patch("strides_ai.analysis.httpx.Client") as MockClient:
+        MockClient.return_value.__enter__.return_value.get.return_value = mock_response
+        with pytest.raises(RateLimitError):
+            fetch_activity_streams(12345, "fake_token")
+
+
+def test_fetch_streams_network_error_returns_empty():
+    with patch("strides_ai.analysis.httpx.Client") as MockClient:
+        MockClient.return_value.__enter__.return_value.get.side_effect = Exception("timeout")
+        result = fetch_activity_streams(12345, "fake_token")
+
+    assert result == {}
+
+
+# ── renormalize_effort_efficiency ─────────────────────────────────────────────
+
+
+def test_renormalize_effort_efficiency(tmp_db):
+    """Most efficient activity (lowest raw ratio) should score 100."""
+    # Insert 3 activities with different efficiency: lower raw = more efficient
+    for i, (activity_id, raw) in enumerate([(1, 1.5), (2, 2.5), (3, 3.5)], 1):
+        db.upsert_activity(
+            {
+                "id": activity_id,
+                "name": f"Run {i}",
+                "start_date_local": f"2025-0{i}-01T07:00:00Z",
+                "distance": 10000,
+                "moving_time": 3600,
+                "elapsed_time": 3700,
+                "sport_type": "Run",
+            }
+        )
+        db.save_analysis(activity_id, {"effort_efficiency_raw": raw})
+
+    db.renormalize_effort_efficiency()
+
+    activities = db.get_all_activities()
+    scores = {a["id"]: a["effort_efficiency_score"] for a in activities}
+
+    # Activity 1 has lowest raw (most efficient) → should score 100
+    assert scores[1] == pytest.approx(100.0)
+    # Activity 3 has highest raw (least efficient) → should score 0
+    assert scores[3] == pytest.approx(0.0)
+    # Activity 2 is in the middle
+    assert 0 < scores[2] < 100
+
+
+def test_renormalize_single_activity_scores_50(tmp_db):
+    db.upsert_activity(
+        {
+            "id": 1,
+            "name": "Solo Run",
+            "start_date_local": "2025-01-01T07:00:00Z",
+            "distance": 10000,
+            "moving_time": 3600,
+            "elapsed_time": 3700,
+            "sport_type": "Run",
+        }
+    )
+    db.save_analysis(1, {"effort_efficiency_raw": 2.0})
+    db.renormalize_effort_efficiency()
+
+    row = db.get_all_activities()[0]
+    assert row["effort_efficiency_score"] == pytest.approx(50.0)
+
+
+# ── condense_streams_for_deep_dive ────────────────────────────────────────────
+
+
+def test_condense_streams_produces_table():
+    streams = {
+        "time": list(range(0, 600, 10)),
+        "heartrate": [150] * 60,
+        "velocity_smooth": [3.0] * 60,
+        "cadence": [90.0] * 60,
+        "altitude": [100.0] * 60,
+    }
+    activity = {
+        "id": 1,
+        "name": "Test Run",
+        "date": "2025-06-15",
+        "distance_m": 1800,
+        "sport_type": "Run",
+    }
+    output = condense_streams_for_deep_dive(streams, activity)
+    assert "ELAPSED" in output
+    assert "PACE" in output
+    assert "HR" in output
+
+
+def test_condense_streams_empty_returns_fallback():
+    output = condense_streams_for_deep_dive({}, {"id": 1, "name": "Empty"})
+    assert "No stream data" in output
+
+
+def test_condense_streams_cycling_shows_speed():
+    streams = {
+        "time": list(range(0, 600, 10)),
+        "velocity_smooth": [8.0] * 60,
+    }
+    activity = {
+        "id": 1,
+        "name": "Ride",
+        "date": "2025-06-15",
+        "distance_m": 4800,
+        "sport_type": "Ride",
+    }
+    output = condense_streams_for_deep_dive(streams, activity)
+    assert "SPEED" in output
+    assert "PACE" not in output

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -34,6 +34,7 @@ interface Activity {
   suffer_score_mismatch_flag: number | null;
   deep_dive_report: string | null;
   deep_dive_completed_at: string | null;
+  deep_dive_model: string | null;
   user_notes: string | null;
 }
 
@@ -175,6 +176,7 @@ export default function Activities({ mode, theme }: Props) {
   // Slide-out panel state
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [deepDiveReport, setDeepDiveReport] = useState<string>("");
+  const [deepDiveModel, setDeepDiveModel] = useState<string>("");
   const [deepDiveLoading, setDeepDiveLoading] = useState(false);
   const [deepDiveError, setDeepDiveError] = useState("");
   const [notes, setNotes] = useState<string>("");
@@ -195,6 +197,7 @@ export default function Activities({ mode, theme }: Props) {
     const act = activities.find((a) => a.id === id);
     setSelectedId(id);
     setDeepDiveReport(act?.deep_dive_report ?? "");
+    setDeepDiveModel(act?.deep_dive_model ?? "");
     setDeepDiveError("");
     setDeepDiveLoading(false);
     setNotes(act?.user_notes ?? "");
@@ -204,6 +207,7 @@ export default function Activities({ mode, theme }: Props) {
   function closePanel() {
     setSelectedId(null);
     setDeepDiveReport("");
+    setDeepDiveModel("");
     setDeepDiveError("");
     setDeepDiveLoading(false);
     setNotes("");
@@ -249,8 +253,13 @@ export default function Activities({ mode, theme }: Props) {
       }
       const data = await res.json();
       setDeepDiveReport(data.report);
+      setDeepDiveModel(data.model ?? "");
       setActivities((prev) =>
-        prev.map((a) => (a.id === selectedId ? { ...a, deep_dive_report: data.report } : a))
+        prev.map((a) =>
+          a.id === selectedId
+            ? { ...a, deep_dive_report: data.report, deep_dive_model: data.model ?? null }
+            : a
+        )
       );
     } catch {
       setDeepDiveError("Network error — could not complete deep dive.");
@@ -703,11 +712,18 @@ export default function Activities({ mode, theme }: Props) {
 
                 {!deepDiveLoading && (deepDiveReport || selectedActivity.deep_dive_report) && (
                   <>
-                    {selectedActivity.deep_dive_completed_at && !deepDiveReport && (
-                      <p className="text-xs text-gray-600">
-                        Generated {new Date(selectedActivity.deep_dive_completed_at).toLocaleString()}
-                      </p>
-                    )}
+                    <div className="flex items-center gap-3 flex-wrap">
+                      {selectedActivity.deep_dive_completed_at && !deepDiveReport && (
+                        <p className="text-xs text-gray-600">
+                          Generated {new Date(selectedActivity.deep_dive_completed_at).toLocaleString()}
+                        </p>
+                      )}
+                      {(deepDiveModel || selectedActivity.deep_dive_model) && (
+                        <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-gray-800 text-gray-500 border border-gray-700">
+                          {deepDiveModel || selectedActivity.deep_dive_model}
+                        </span>
+                      )}
+                    </div>
                     <div className="prose prose-invert prose-sm max-w-none text-gray-300 [&_h1]:text-base [&_h2]:text-sm [&_h3]:text-sm [&_ul]:pl-4 [&_ol]:pl-4 [&_li]:my-0.5 [&_p]:my-1.5 [&_strong]:text-gray-100 [&_hr]:border-gray-700">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
                         {deepDiveReport || selectedActivity.deep_dive_report || ""}

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type { Mode, ThemeConfig } from "../App";
 
 interface Activity {
@@ -482,7 +484,7 @@ export default function Activities({ mode, theme }: Props) {
           />
 
           {/* Panel */}
-          <div className="fixed right-0 top-0 h-full w-full max-w-lg z-50 bg-gray-950 border-l border-gray-800 flex flex-col shadow-2xl">
+          <div className="fixed right-0 top-0 h-full w-full max-w-2xl z-50 bg-gray-950 border-l border-gray-800 flex flex-col shadow-2xl">
 
             {/* Panel header */}
             <div className="px-5 py-4 border-b border-gray-800 flex items-start justify-between gap-3">
@@ -657,9 +659,11 @@ export default function Activities({ mode, theme }: Props) {
                         Generated {new Date(selectedActivity.deep_dive_completed_at).toLocaleString()}
                       </p>
                     )}
-                    <pre className="text-sm text-gray-300 whitespace-pre-wrap font-sans leading-relaxed">
-                      {deepDiveReport || selectedActivity.deep_dive_report}
-                    </pre>
+                    <div className="prose prose-invert prose-sm max-w-none text-gray-300 [&_h1]:text-base [&_h2]:text-sm [&_h3]:text-sm [&_ul]:pl-4 [&_ol]:pl-4 [&_li]:my-0.5 [&_p]:my-1.5 [&_strong]:text-gray-100 [&_hr]:border-gray-700">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {deepDiveReport || selectedActivity.deep_dive_report || ""}
+                      </ReactMarkdown>
+                    </div>
                   </>
                 )}
               </section>

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -12,11 +12,26 @@ interface Activity {
   max_hr: number | null;
   elevation_gain_m: number | null;
   sport_type: string | null;
+  suffer_score: number | null;
+  avg_cadence: number | null;
+  // Analysis fields
   analysis_summary: string | null;
+  analysis_status: string | null;
   cardiac_decoupling_pct: number | null;
   effort_efficiency_score: number | null;
-  analysis_status: string | null;
+  effort_efficiency_raw: number | null;
+  hr_zone_1_pct: number | null;
+  hr_zone_2_pct: number | null;
+  hr_zone_3_pct: number | null;
+  hr_zone_4_pct: number | null;
+  hr_zone_5_pct: number | null;
+  pace_fade_seconds: number | null;
+  cadence_std_dev: number | null;
+  elevation_per_mile: number | null;
+  high_elevation_flag: number | null;
+  suffer_score_mismatch_flag: number | null;
   deep_dive_report: string | null;
+  deep_dive_completed_at: string | null;
 }
 
 interface Props {
@@ -47,6 +62,12 @@ function formatDuration(s: number): string {
   return `${m}m${String(sec).padStart(2, "0")}s`;
 }
 
+function formatPaceFade(s: number | null): string {
+  if (s === null) return "—";
+  const abs = Math.round(Math.abs(s));
+  return s > 0 ? `+${abs}s/mi` : `−${abs}s/mi`;
+}
+
 function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
   return (
     <span className={`ml-1 inline-block transition-opacity ${active ? "opacity-100" : "opacity-0 group-hover:opacity-40"}`}>
@@ -73,6 +94,65 @@ function EfficiencyBadge({ val }: { val: number | null }) {
   return <span className="px-1.5 py-0.5 rounded text-xs bg-red-900 text-red-300" title="Effort efficiency score">{Math.round(val)} EFF</span>;
 }
 
+/** Single metric tile for the panel grid. */
+function MetricTile({
+  label,
+  value,
+  sub,
+  color = "default",
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  color?: "green" | "yellow" | "red" | "default";
+}) {
+  const valueClass =
+    color === "green"  ? "text-green-400"  :
+    color === "yellow" ? "text-yellow-400" :
+    color === "red"    ? "text-red-400"    :
+    "text-gray-100";
+  return (
+    <div className="bg-gray-800 rounded-lg px-3 py-2.5">
+      <p className="text-xs text-gray-500 mb-0.5">{label}</p>
+      <p className={`text-sm font-semibold ${valueClass}`}>{value}</p>
+      {sub && <p className="text-xs text-gray-600 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+/** HR zone stacked bar with legend. */
+function HrZonesBar({ a }: { a: Activity }) {
+  const z1 = a.hr_zone_1_pct ?? 0;
+  const z2 = a.hr_zone_2_pct ?? 0;
+  const z3 = a.hr_zone_3_pct ?? 0;
+  const z4 = a.hr_zone_4_pct ?? 0;
+  const z5 = a.hr_zone_5_pct ?? 0;
+  if (!a.hr_zone_1_pct && !a.hr_zone_2_pct) return null;
+
+  return (
+    <div>
+      <p className="text-xs text-gray-500 mb-1.5">HR Zone Distribution</p>
+      <div className="flex h-5 rounded overflow-hidden gap-px">
+        {z1 > 0 && <div style={{ width: `${z1}%` }} className="bg-gray-500" title={`Z1 ${z1.toFixed(0)}%`} />}
+        {z2 > 0 && <div style={{ width: `${z2}%` }} className="bg-blue-600" title={`Z2 ${z2.toFixed(0)}%`} />}
+        {z3 > 0 && <div style={{ width: `${z3}%` }} className="bg-yellow-500" title={`Z3 ${z3.toFixed(0)}%`} />}
+        {z4 > 0 && <div style={{ width: `${z4}%` }} className="bg-orange-500" title={`Z4 ${z4.toFixed(0)}%`} />}
+        {z5 > 0 && <div style={{ width: `${z5}%` }} className="bg-red-500"    title={`Z5 ${z5.toFixed(0)}%`} />}
+      </div>
+      <div className="flex gap-3 mt-1.5 flex-wrap">
+        {[["Z1", z1, "bg-gray-500"], ["Z2", z2, "bg-blue-600"], ["Z3", z3, "bg-yellow-500"], ["Z4", z4, "bg-orange-500"], ["Z5", z5, "bg-red-500"]].map(([label, pct, cls]) =>
+          (pct as number) > 0 ? (
+            <span key={label as string} className="flex items-center gap-1 text-xs text-gray-400">
+              <span className={`inline-block w-2 h-2 rounded-sm ${cls}`} />
+              {label} {(pct as number).toFixed(0)}%
+            </span>
+          ) : null
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function Activities({ mode, theme }: Props) {
   const [activities, setActivities] = useState<Activity[]>([]);
   const [loading, setLoading] = useState(true);
@@ -89,11 +169,13 @@ export default function Activities({ mode, theme }: Props) {
   const [dateTo, setDateTo] = useState("");
   const [minDist, setMinDist] = useState("");
 
-  // Deep dive modal state
-  const [deepDiveId, setDeepDiveId] = useState<number | null>(null);
+  // Slide-out panel state
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const [deepDiveReport, setDeepDiveReport] = useState<string>("");
   const [deepDiveLoading, setDeepDiveLoading] = useState(false);
   const [deepDiveError, setDeepDiveError] = useState("");
+
+  const selectedActivity = activities.find((a) => a.id === selectedId) ?? null;
 
   useEffect(() => {
     setLoading(true);
@@ -102,6 +184,21 @@ export default function Activities({ mode, theme }: Props) {
       .then(setActivities)
       .finally(() => setLoading(false));
   }, [mode]);
+
+  function openPanel(id: number) {
+    const act = activities.find((a) => a.id === id);
+    setSelectedId(id);
+    setDeepDiveReport(act?.deep_dive_report ?? "");
+    setDeepDiveError("");
+    setDeepDiveLoading(false);
+  }
+
+  function closePanel() {
+    setSelectedId(null);
+    setDeepDiveReport("");
+    setDeepDiveError("");
+    setDeepDiveLoading(false);
+  }
 
   async function handleSync() {
     setSyncing(true);
@@ -123,22 +220,17 @@ export default function Activities({ mode, theme }: Props) {
     }
   }
 
-  async function handleDeepDive(activityId: number, force = false) {
-    setDeepDiveId(activityId);
-    setDeepDiveReport("");
+  async function runDeepDive(force = false) {
+    if (selectedId === null) return;
     setDeepDiveError("");
     setDeepDiveLoading(true);
-
-    // Check if there's already a cached report
-    const cached = activities.find((a) => a.id === activityId);
-    if (cached?.deep_dive_report && !force) {
-      setDeepDiveReport(cached.deep_dive_report);
+    if (!force && selectedActivity?.deep_dive_report) {
+      setDeepDiveReport(selectedActivity.deep_dive_report);
       setDeepDiveLoading(false);
       return;
     }
-
     try {
-      const url = `/api/activities/${activityId}/deep-dive${force ? "?force=true" : ""}`;
+      const url = `/api/activities/${selectedId}/deep-dive${force ? "?force=true" : ""}`;
       const res = await fetch(url, { method: "POST" });
       if (!res.ok) {
         const err = await res.json().catch(() => ({ detail: "Request failed" }));
@@ -147,9 +239,8 @@ export default function Activities({ mode, theme }: Props) {
       }
       const data = await res.json();
       setDeepDiveReport(data.report);
-      // Update the cached report in local state
       setActivities((prev) =>
-        prev.map((a) => (a.id === activityId ? { ...a, deep_dive_report: data.report } : a))
+        prev.map((a) => (a.id === selectedId ? { ...a, deep_dive_report: data.report } : a))
       );
     } catch {
       setDeepDiveError("Network error — could not complete deep dive.");
@@ -169,7 +260,6 @@ export default function Activities({ mode, theme }: Props) {
 
   const filtered = useMemo(() => {
     let rows = activities;
-
     if (search.trim()) {
       const q = search.toLowerCase();
       rows = rows.filter((a) => (a.name ?? "").toLowerCase().includes(q));
@@ -190,15 +280,7 @@ export default function Activities({ mode, theme }: Props) {
   const paceLabel = mode === "cycling" ? "Speed" : mode === "hybrid" ? "Pace/Speed" : "Pace";
   const focusClass = "focus:outline-none focus:border-gray-500";
 
-  function Th({
-    label,
-    col,
-    right = false,
-  }: {
-    label: string;
-    col: SortKey;
-    right?: boolean;
-  }) {
+  function Th({ label, col, right = false }: { label: string; col: SortKey; right?: boolean }) {
     return (
       <th
         onClick={() => handleSort(col)}
@@ -212,7 +294,36 @@ export default function Activities({ mode, theme }: Props) {
 
   const filtersActive = search || dateFrom || dateTo || minDist;
 
-  const deepDiveActivity = activities.find((a) => a.id === deepDiveId);
+  // ── Panel helpers ────────────────────────────────────────────────────────
+
+  function cdColor(v: number | null): "green" | "yellow" | "red" | "default" {
+    if (v === null) return "default";
+    if (v < 5) return "green";
+    if (v < 10) return "yellow";
+    return "red";
+  }
+
+  function effColor(v: number | null): "green" | "yellow" | "red" | "default" {
+    if (v === null) return "default";
+    if (v > 66) return "green";
+    if (v >= 33) return "yellow";
+    return "red";
+  }
+
+  function paceLabel2(a: Activity): string {
+    const isCycle = a.sport_type === "Ride" || a.sport_type === "VirtualRide" || a.sport_type === "GravelRide";
+    if (mode === "cycling" || isCycle) return formatSpeed(a.avg_pace_s_per_km);
+    return formatPace(a.avg_pace_s_per_km);
+  }
+
+  const hasMetrics = selectedActivity && (
+    selectedActivity.cardiac_decoupling_pct !== null ||
+    selectedActivity.effort_efficiency_score !== null ||
+    selectedActivity.pace_fade_seconds !== null ||
+    selectedActivity.avg_cadence !== null ||
+    selectedActivity.elevation_per_mile !== null ||
+    selectedActivity.hr_zone_1_pct !== null
+  );
 
   return (
     <div className="flex flex-col h-full p-6 gap-3">
@@ -294,7 +405,7 @@ export default function Activities({ mode, theme }: Props) {
                 <Th label={paceLabel} col="avg_pace_s_per_km" right />
                 <Th label="Avg HR"    col="avg_hr"            right />
                 <Th label="Elev (m)"  col="elevation_gain_m"  right />
-                <th className="px-4 py-2 font-medium whitespace-nowrap text-right">Deep Dive</th>
+                <th className="px-4 py-2 font-medium whitespace-nowrap text-right"></th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-800">
@@ -306,17 +417,14 @@ export default function Activities({ mode, theme }: Props) {
                 </tr>
               ) : (
                 filtered.map((a) => (
-                  <tr key={a.id} className="hover:bg-gray-800/50 transition-colors">
+                  <tr
+                    key={a.id}
+                    className={`hover:bg-gray-800/50 transition-colors cursor-pointer ${selectedId === a.id ? "bg-gray-800/60" : ""}`}
+                    onClick={() => openPanel(a.id)}
+                  >
                     <td className="px-4 py-2 text-gray-400 whitespace-nowrap">{a.date}</td>
                     <td className="px-4 py-2">
-                      <a
-                        href={`https://www.strava.com/activities/${a.id}`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-gray-100 hover:text-orange-400 transition-colors"
-                      >
-                        {a.name || "—"}
-                      </a>
+                      <span className="text-gray-100">{a.name || "—"}</span>
                       {a.analysis_summary && (
                         <p className="text-xs text-gray-500 mt-0.5 max-w-xs truncate">{a.analysis_summary}</p>
                       )}
@@ -348,12 +456,12 @@ export default function Activities({ mode, theme }: Props) {
                     <td className="px-4 py-2 text-right text-gray-400">
                       {a.elevation_gain_m != null ? Math.round(a.elevation_gain_m) : "—"}
                     </td>
-                    <td className="px-4 py-2 text-right">
+                    <td className="px-4 py-2 text-right" onClick={(e) => e.stopPropagation()}>
                       <button
-                        onClick={() => handleDeepDive(a.id)}
+                        onClick={() => openPanel(a.id)}
                         className="px-2 py-1 rounded text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors whitespace-nowrap"
                       >
-                        {a.deep_dive_report ? "View Dive" : "Deep Dive"}
+                        {a.analysis_status === "done" ? "Details ›" : "Details"}
                       </button>
                     </td>
                   </tr>
@@ -364,61 +472,200 @@ export default function Activities({ mode, theme }: Props) {
         </div>
       )}
 
-      {/* Deep Dive Modal */}
-      {deepDiveId !== null && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
-          onClick={(e) => { if (e.target === e.currentTarget) setDeepDiveId(null); }}
-        >
-          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-3xl max-h-[85vh] flex flex-col mx-4">
-            {/* Modal header */}
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-800">
-              <div>
-                <h3 className="text-gray-100 font-semibold">Deep Dive Analysis</h3>
-                {deepDiveActivity && (
-                  <p className="text-xs text-gray-500 mt-0.5">{deepDiveActivity.name} · {deepDiveActivity.date}</p>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                {!deepDiveLoading && deepDiveReport && (
-                  <button
-                    onClick={() => handleDeepDive(deepDiveId, true)}
-                    className="px-2 py-1 rounded text-xs bg-gray-700 hover:bg-gray-600 text-gray-400 transition-colors"
+      {/* ── Slide-out panel ──────────────────────────────────────────────── */}
+      {selectedActivity && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40 bg-black/50"
+            onClick={closePanel}
+          />
+
+          {/* Panel */}
+          <div className="fixed right-0 top-0 h-full w-full max-w-lg z-50 bg-gray-950 border-l border-gray-800 flex flex-col shadow-2xl">
+
+            {/* Panel header */}
+            <div className="px-5 py-4 border-b border-gray-800 flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h3 className="text-gray-100 font-semibold truncate">{selectedActivity.name || "Activity"}</h3>
+                  <a
+                    href={`https://www.strava.com/activities/${selectedActivity.id}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="text-xs text-orange-500 hover:text-orange-400 transition-colors shrink-0"
                   >
-                    Regenerate
-                  </button>
-                )}
-                <button
-                  onClick={() => setDeepDiveId(null)}
-                  className="text-gray-500 hover:text-gray-300 transition-colors text-lg leading-none"
-                >
-                  ×
-                </button>
+                    Strava ↗
+                  </a>
+                </div>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  {selectedActivity.date}
+                  {selectedActivity.sport_type ? ` · ${selectedActivity.sport_type}` : ""}
+                </p>
               </div>
+              <button
+                onClick={closePanel}
+                className="text-gray-500 hover:text-gray-300 transition-colors text-xl leading-none shrink-0 mt-0.5"
+              >
+                ×
+              </button>
             </div>
 
-            {/* Modal body */}
-            <div className="overflow-y-auto flex-1 px-6 py-4">
-              {deepDiveLoading && (
-                <div className="flex items-center gap-3 text-gray-400">
-                  <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-                  </svg>
-                  <span className="text-sm">Analyzing your run… this may take 10–20 seconds.</span>
+            {/* Panel body — scrollable */}
+            <div className="overflow-y-auto flex-1 p-5 space-y-6">
+
+              {/* Basic stats row */}
+              <div className="grid grid-cols-4 gap-2">
+                <MetricTile
+                  label="Distance"
+                  value={`${((selectedActivity.distance_m || 0) / 1000).toFixed(2)} km`}
+                />
+                <MetricTile
+                  label="Time"
+                  value={formatDuration(selectedActivity.moving_time_s)}
+                />
+                <MetricTile
+                  label={mode === "cycling" ? "Speed" : "Pace"}
+                  value={paceLabel2(selectedActivity)}
+                />
+                <MetricTile
+                  label="Avg HR"
+                  value={selectedActivity.avg_hr ? `${Math.round(selectedActivity.avg_hr)} bpm` : "—"}
+                />
+              </div>
+
+              {/* Analysis summary */}
+              {selectedActivity.analysis_summary && (
+                <div className="bg-gray-800/60 rounded-lg px-4 py-3 border border-gray-700">
+                  <p className="text-xs text-gray-500 mb-1">Analysis Summary</p>
+                  <p className="text-sm text-gray-200 leading-relaxed">{selectedActivity.analysis_summary}</p>
                 </div>
               )}
-              {deepDiveError && (
-                <p className="text-red-400 text-sm">{deepDiveError}</p>
+
+              {/* Metrics grid */}
+              {hasMetrics && (
+                <section className="space-y-3">
+                  <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Computed Metrics</h4>
+
+                  <div className="grid grid-cols-2 gap-2">
+                    {selectedActivity.cardiac_decoupling_pct !== null && (
+                      <MetricTile
+                        label="Cardiac Decoupling"
+                        value={`${selectedActivity.cardiac_decoupling_pct.toFixed(1)}%`}
+                        sub={selectedActivity.cardiac_decoupling_pct < 5 ? "Excellent" : selectedActivity.cardiac_decoupling_pct < 10 ? "Moderate stress" : "High drift"}
+                        color={cdColor(selectedActivity.cardiac_decoupling_pct)}
+                      />
+                    )}
+                    {selectedActivity.effort_efficiency_score !== null && (
+                      <MetricTile
+                        label="Effort Efficiency"
+                        value={`${Math.round(selectedActivity.effort_efficiency_score)} / 100`}
+                        sub="Normalized vs history"
+                        color={effColor(selectedActivity.effort_efficiency_score)}
+                      />
+                    )}
+                    {selectedActivity.pace_fade_seconds !== null && (
+                      <MetricTile
+                        label="Pace Fade"
+                        value={formatPaceFade(selectedActivity.pace_fade_seconds)}
+                        sub={selectedActivity.pace_fade_seconds > 15 ? "Slowed in final third" : selectedActivity.pace_fade_seconds < -15 ? "Negative split" : "Even pacing"}
+                        color={selectedActivity.pace_fade_seconds > 15 ? "yellow" : selectedActivity.pace_fade_seconds < -15 ? "green" : "default"}
+                      />
+                    )}
+                    {selectedActivity.avg_cadence !== null && (
+                      <MetricTile
+                        label={selectedActivity.sport_type && (selectedActivity.sport_type === "Ride" || selectedActivity.sport_type === "VirtualRide" || selectedActivity.sport_type === "GravelRide") ? "Cadence (rpm)" : "Cadence (spm)"}
+                        value={`${Math.round(selectedActivity.avg_cadence)}`}
+                        sub={selectedActivity.cadence_std_dev !== null ? `±${selectedActivity.cadence_std_dev.toFixed(1)} std dev` : undefined}
+                      />
+                    )}
+                    {selectedActivity.elevation_per_mile !== null && (
+                      <MetricTile
+                        label="Elevation / Mile"
+                        value={`${selectedActivity.elevation_per_mile.toFixed(0)} ft/mi`}
+                        sub={selectedActivity.high_elevation_flag ? "Hilly course" : "Flat to moderate"}
+                        color={selectedActivity.high_elevation_flag ? "yellow" : "default"}
+                      />
+                    )}
+                    {selectedActivity.suffer_score_mismatch_flag === 1 && (
+                      <MetricTile
+                        label="HR Reliability"
+                        value="⚠ Mismatch"
+                        sub="Suffer score vs HR zones inconsistent"
+                        color="yellow"
+                      />
+                    )}
+                  </div>
+
+                  <HrZonesBar a={selectedActivity} />
+                </section>
               )}
-              {deepDiveReport && !deepDiveLoading && (
-                <pre className="text-gray-300 text-sm whitespace-pre-wrap font-sans leading-relaxed">
-                  {deepDiveReport}
-                </pre>
+
+              {/* No analysis yet */}
+              {!hasMetrics && selectedActivity.analysis_status !== "done" && (
+                <p className="text-sm text-gray-600">
+                  {selectedActivity.analysis_status === "skipped"
+                    ? "No stream data available for this activity."
+                    : selectedActivity.analysis_status === "error"
+                    ? "Analysis failed for this activity."
+                    : "Analysis pending — will run on next sync."}
+                </p>
               )}
+
+              {/* ── Deep Dive ─────────────────────────────────────────── */}
+              <section className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Deep Dive Analysis</h4>
+                  {(deepDiveReport || selectedActivity.deep_dive_report) && !deepDiveLoading && (
+                    <button
+                      onClick={() => runDeepDive(true)}
+                      className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+                    >
+                      Regenerate
+                    </button>
+                  )}
+                </div>
+
+                {deepDiveLoading && (
+                  <div className="flex items-center gap-3 text-gray-400">
+                    <svg className="animate-spin h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                    </svg>
+                    <span className="text-sm text-gray-400">Analyzing… this may take 10–20 seconds.</span>
+                  </div>
+                )}
+
+                {deepDiveError && (
+                  <p className="text-sm text-red-400">{deepDiveError}</p>
+                )}
+
+                {!deepDiveLoading && !deepDiveReport && !selectedActivity.deep_dive_report && !deepDiveError && (
+                  <button
+                    onClick={() => runDeepDive()}
+                    className={`px-4 py-2 rounded-lg text-sm font-medium ${theme.accentButton} text-white transition-colors`}
+                  >
+                    Run Deep Dive
+                  </button>
+                )}
+
+                {!deepDiveLoading && (deepDiveReport || selectedActivity.deep_dive_report) && (
+                  <>
+                    {selectedActivity.deep_dive_completed_at && !deepDiveReport && (
+                      <p className="text-xs text-gray-600">
+                        Generated {new Date(selectedActivity.deep_dive_completed_at).toLocaleString()}
+                      </p>
+                    )}
+                    <pre className="text-sm text-gray-300 whitespace-pre-wrap font-sans leading-relaxed">
+                      {deepDiveReport || selectedActivity.deep_dive_report}
+                    </pre>
+                  </>
+                )}
+              </section>
             </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -34,6 +34,7 @@ interface Activity {
   suffer_score_mismatch_flag: number | null;
   deep_dive_report: string | null;
   deep_dive_completed_at: string | null;
+  user_notes: string | null;
 }
 
 interface Props {
@@ -176,6 +177,9 @@ export default function Activities({ mode, theme }: Props) {
   const [deepDiveReport, setDeepDiveReport] = useState<string>("");
   const [deepDiveLoading, setDeepDiveLoading] = useState(false);
   const [deepDiveError, setDeepDiveError] = useState("");
+  const [notes, setNotes] = useState<string>("");
+  const [notesSaving, setNotesSaving] = useState(false);
+  const [notesSaved, setNotesSaved] = useState(false);
 
   const selectedActivity = activities.find((a) => a.id === selectedId) ?? null;
 
@@ -193,6 +197,8 @@ export default function Activities({ mode, theme }: Props) {
     setDeepDiveReport(act?.deep_dive_report ?? "");
     setDeepDiveError("");
     setDeepDiveLoading(false);
+    setNotes(act?.user_notes ?? "");
+    setNotesSaved(false);
   }
 
   function closePanel() {
@@ -200,6 +206,8 @@ export default function Activities({ mode, theme }: Props) {
     setDeepDiveReport("");
     setDeepDiveError("");
     setDeepDiveLoading(false);
+    setNotes("");
+    setNotesSaved(false);
   }
 
   async function handleSync() {
@@ -248,6 +256,25 @@ export default function Activities({ mode, theme }: Props) {
       setDeepDiveError("Network error — could not complete deep dive.");
     } finally {
       setDeepDiveLoading(false);
+    }
+  }
+
+  async function saveNotes() {
+    if (selectedId === null) return;
+    setNotesSaving(true);
+    setNotesSaved(false);
+    try {
+      await fetch(`/api/activities/${selectedId}/notes`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes }),
+      });
+      setActivities((prev) =>
+        prev.map((a) => (a.id === selectedId ? { ...a, user_notes: notes } : a))
+      );
+      setNotesSaved(true);
+    } finally {
+      setNotesSaving(false);
     }
   }
 
@@ -614,6 +641,28 @@ export default function Activities({ mode, theme }: Props) {
                     : "Analysis pending — will run on next sync."}
                 </p>
               )}
+
+              {/* ── User Notes ───────────────────────────────────────── */}
+              <section className="space-y-2">
+                <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Your Notes</h4>
+                <textarea
+                  value={notes}
+                  onChange={(e) => { setNotes(e.target.value); setNotesSaved(false); }}
+                  placeholder="Add context for the Deep Dive — how you felt, goals, weather, etc."
+                  rows={3}
+                  className="w-full rounded-lg bg-gray-800 border border-gray-700 px-3 py-2 text-sm text-gray-200 placeholder-gray-600 resize-y focus:outline-none focus:border-gray-500"
+                />
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={saveNotes}
+                    disabled={notesSaving}
+                    className="px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-sm text-gray-200 disabled:opacity-50 transition-colors"
+                  >
+                    {notesSaving ? "Saving…" : "Save Notes"}
+                  </button>
+                  {notesSaved && <span className="text-xs text-green-400">Saved</span>}
+                </div>
+              </section>
 
               {/* ── Deep Dive ─────────────────────────────────────────── */}
               <section className="space-y-3">

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -719,7 +719,7 @@ export default function Activities({ mode, theme }: Props) {
                         </p>
                       )}
                       {(deepDiveModel || selectedActivity.deep_dive_model) && (
-                        <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-gray-800 text-gray-500 border border-gray-700">
+                        <span className="text-[10px] text-gray-700 font-mono">
                           {deepDiveModel || selectedActivity.deep_dive_model}
                         </span>
                       )}

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -12,6 +12,11 @@ interface Activity {
   max_hr: number | null;
   elevation_gain_m: number | null;
   sport_type: string | null;
+  analysis_summary: string | null;
+  cardiac_decoupling_pct: number | null;
+  effort_efficiency_score: number | null;
+  analysis_status: string | null;
+  deep_dive_report: string | null;
 }
 
 interface Props {
@@ -50,6 +55,24 @@ function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
   );
 }
 
+function DecouplingBadge({ val }: { val: number | null }) {
+  if (val === null) return null;
+  if (val < 5)
+    return <span className="px-1.5 py-0.5 rounded text-xs bg-green-900 text-green-300" title="Cardiac decoupling">{val.toFixed(1)}% CD</span>;
+  if (val < 10)
+    return <span className="px-1.5 py-0.5 rounded text-xs bg-yellow-900 text-yellow-300" title="Cardiac decoupling">{val.toFixed(1)}% CD</span>;
+  return <span className="px-1.5 py-0.5 rounded text-xs bg-red-900 text-red-300" title="Cardiac decoupling">{val.toFixed(1)}% CD</span>;
+}
+
+function EfficiencyBadge({ val }: { val: number | null }) {
+  if (val === null) return null;
+  if (val > 66)
+    return <span className="px-1.5 py-0.5 rounded text-xs bg-green-900 text-green-300" title="Effort efficiency score">{Math.round(val)} EFF</span>;
+  if (val >= 33)
+    return <span className="px-1.5 py-0.5 rounded text-xs bg-yellow-900 text-yellow-300" title="Effort efficiency score">{Math.round(val)} EFF</span>;
+  return <span className="px-1.5 py-0.5 rounded text-xs bg-red-900 text-red-300" title="Effort efficiency score">{Math.round(val)} EFF</span>;
+}
+
 export default function Activities({ mode, theme }: Props) {
   const [activities, setActivities] = useState<Activity[]>([]);
   const [loading, setLoading] = useState(true);
@@ -65,6 +88,12 @@ export default function Activities({ mode, theme }: Props) {
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [minDist, setMinDist] = useState("");
+
+  // Deep dive modal state
+  const [deepDiveId, setDeepDiveId] = useState<number | null>(null);
+  const [deepDiveReport, setDeepDiveReport] = useState<string>("");
+  const [deepDiveLoading, setDeepDiveLoading] = useState(false);
+  const [deepDiveError, setDeepDiveError] = useState("");
 
   useEffect(() => {
     setLoading(true);
@@ -91,6 +120,41 @@ export default function Activities({ mode, theme }: Props) {
       setSyncMsg("Sync failed.");
     } finally {
       setSyncing(false);
+    }
+  }
+
+  async function handleDeepDive(activityId: number, force = false) {
+    setDeepDiveId(activityId);
+    setDeepDiveReport("");
+    setDeepDiveError("");
+    setDeepDiveLoading(true);
+
+    // Check if there's already a cached report
+    const cached = activities.find((a) => a.id === activityId);
+    if (cached?.deep_dive_report && !force) {
+      setDeepDiveReport(cached.deep_dive_report);
+      setDeepDiveLoading(false);
+      return;
+    }
+
+    try {
+      const url = `/api/activities/${activityId}/deep-dive${force ? "?force=true" : ""}`;
+      const res = await fetch(url, { method: "POST" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: "Request failed" }));
+        setDeepDiveError(err.detail || "Deep dive failed.");
+        return;
+      }
+      const data = await res.json();
+      setDeepDiveReport(data.report);
+      // Update the cached report in local state
+      setActivities((prev) =>
+        prev.map((a) => (a.id === activityId ? { ...a, deep_dive_report: data.report } : a))
+      );
+    } catch {
+      setDeepDiveError("Network error — could not complete deep dive.");
+    } finally {
+      setDeepDiveLoading(false);
     }
   }
 
@@ -147,6 +211,8 @@ export default function Activities({ mode, theme }: Props) {
   }
 
   const filtersActive = search || dateFrom || dateTo || minDist;
+
+  const deepDiveActivity = activities.find((a) => a.id === deepDiveId);
 
   return (
     <div className="flex flex-col h-full p-6 gap-3">
@@ -228,12 +294,13 @@ export default function Activities({ mode, theme }: Props) {
                 <Th label={paceLabel} col="avg_pace_s_per_km" right />
                 <Th label="Avg HR"    col="avg_hr"            right />
                 <Th label="Elev (m)"  col="elevation_gain_m"  right />
+                <th className="px-4 py-2 font-medium whitespace-nowrap text-right">Deep Dive</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-800">
               {filtered.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="px-4 py-8 text-center text-gray-500">
+                  <td colSpan={8} className="px-4 py-8 text-center text-gray-500">
                     No activities match your filters.
                   </td>
                 </tr>
@@ -250,6 +317,15 @@ export default function Activities({ mode, theme }: Props) {
                       >
                         {a.name || "—"}
                       </a>
+                      {a.analysis_summary && (
+                        <p className="text-xs text-gray-500 mt-0.5 max-w-xs truncate">{a.analysis_summary}</p>
+                      )}
+                      {(a.cardiac_decoupling_pct !== null || a.effort_efficiency_score !== null) && (
+                        <div className="flex gap-1 mt-1 flex-wrap">
+                          <DecouplingBadge val={a.cardiac_decoupling_pct} />
+                          <EfficiencyBadge val={a.effort_efficiency_score} />
+                        </div>
+                      )}
                     </td>
                     <td className="px-4 py-2 text-right text-gray-100">
                       {((a.distance_m || 0) / 1000).toFixed(2)}
@@ -272,11 +348,76 @@ export default function Activities({ mode, theme }: Props) {
                     <td className="px-4 py-2 text-right text-gray-400">
                       {a.elevation_gain_m != null ? Math.round(a.elevation_gain_m) : "—"}
                     </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        onClick={() => handleDeepDive(a.id)}
+                        className="px-2 py-1 rounded text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors whitespace-nowrap"
+                      >
+                        {a.deep_dive_report ? "View Dive" : "Deep Dive"}
+                      </button>
+                    </td>
                   </tr>
                 ))
               )}
             </tbody>
           </table>
+        </div>
+      )}
+
+      {/* Deep Dive Modal */}
+      {deepDiveId !== null && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          onClick={(e) => { if (e.target === e.currentTarget) setDeepDiveId(null); }}
+        >
+          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-3xl max-h-[85vh] flex flex-col mx-4">
+            {/* Modal header */}
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-800">
+              <div>
+                <h3 className="text-gray-100 font-semibold">Deep Dive Analysis</h3>
+                {deepDiveActivity && (
+                  <p className="text-xs text-gray-500 mt-0.5">{deepDiveActivity.name} · {deepDiveActivity.date}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {!deepDiveLoading && deepDiveReport && (
+                  <button
+                    onClick={() => handleDeepDive(deepDiveId, true)}
+                    className="px-2 py-1 rounded text-xs bg-gray-700 hover:bg-gray-600 text-gray-400 transition-colors"
+                  >
+                    Regenerate
+                  </button>
+                )}
+                <button
+                  onClick={() => setDeepDiveId(null)}
+                  className="text-gray-500 hover:text-gray-300 transition-colors text-lg leading-none"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+
+            {/* Modal body */}
+            <div className="overflow-y-auto flex-1 px-6 py-4">
+              {deepDiveLoading && (
+                <div className="flex items-center gap-3 text-gray-400">
+                  <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                  </svg>
+                  <span className="text-sm">Analyzing your run… this may take 10–20 seconds.</span>
+                </div>
+              )}
+              {deepDiveError && (
+                <p className="text-red-400 text-sm">{deepDiveError}</p>
+              )}
+              {deepDiveReport && !deepDiveLoading && (
+                <pre className="text-gray-300 text-sm whitespace-pre-wrap font-sans leading-relaxed">
+                  {deepDiveReport}
+                </pre>
+              )}
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Stream metric computation**: fetches Strava time-series data (HR, pace, cadence, altitude) and computes cardiac decoupling, HR zone distribution (Z1–Z5), pace fade, cadence stats, effort efficiency score (normalized 0–100 vs history), and elevation impact
- **Rule-based NL summary**: generates a plain-text analysis summary per activity with no LLM — stored in `analysis_summary` and surfaced in the training log and chat context
- **Sync pipeline integration**: runs analysis automatically after each sync; respects Strava rate limits (marks pending, retries on next sync); backfills up to 10 pending activities per sync
- **Deep Dive endpoint**: `POST /api/activities/{id}/deep-dive` runs an on-demand LLM analysis using condensed 60s-interval stream data; caches result; supports `?force=true` to regenerate; tags report with the generating model (`backend.label`)
- **Activity panel**: replaces the old modal with a slide-out panel (max-w-2xl) showing metric tiles, a stacked HR zones bar, user notes textarea (saved to DB and injected into the Deep Dive prompt), and the Deep Dive report rendered as markdown
- **DB migrations**: four Alembic migrations adding 19 new columns to `activities` (`cardiac_decoupling_pct`, `hr_zone_1–5_pct`, `pace_fade_seconds`, `cadence_std_dev`, `effort_efficiency_raw/score`, `elevation_per_mile`, `high_elevation_flag`, `suffer_score_mismatch_flag`, `analysis_summary`, `deep_dive_report`, `deep_dive_completed_at`, `deep_dive_model`, `analysis_status`, `user_notes`)

## Test plan

- [x] `POST /api/sync` — check logs for stream fetch and metric columns populated in DB
- [x] Open Activities page — confirm `analysis_summary` subtitle and CD/EFF badges appear on analyzed rows
- [x] Click a row to open the panel — verify metric tiles, HR zones bar, and notes textarea load
- [x] Add notes, save, close and reopen panel — confirm notes persist
- [x] Click "Run Deep Dive" — confirm ~10–20s response, markdown rendering, and model label
- [x] Click "Regenerate" — confirm fresh report replaces cached one
- [x] Start a chat — confirm training log includes ANALYSIS column and metrics guide
- [x] Run `pytest tests/test_analysis.py` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)