### PR TITLE
fix(deps): add missing python-multipart dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sqlmodel>=0.0.21",
     "alembic>=1.13",
     "pydantic-settings>=2.0",
+    "python-multipart>=0.0.9",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Adds `python-multipart>=0.0.9` to `pyproject.toml`
- FastAPI requires this package for form and file upload parsing; without it `make install` on a fresh environment installs successfully but fails at runtime

## Test plan

- [ ] `make install` on a clean environment installs without errors
- [ ] Web server starts and API endpoints respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)