### PR TITLE
feat(profile): add max_hr field to athlete profile

### DIFF
--- a/strides_ai/api/routers/profile.py
+++ b/strides_ai/api/routers/profile.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from sqlmodel import Session
 
 from ...db import profiles as crud
+from ...db import settings as settings_crud
 from ...db.engine import get_session
 from ...profile import get_default_fields
 from ..deps import init_backend
@@ -36,6 +37,9 @@ def put_profile(
 ):
     m = mode or request.app.state.mode
     crud.save_fields(session, m, body.fields)
+    max_hr_val = str(body.fields.get("personal", {}).get("max_hr", "")).strip()
+    if max_hr_val.isdigit():
+        settings_crud.set(session, "max_hr", max_hr_val)
     init_backend(request.app)
     return {"status": "ok"}
 

--- a/strides_ai/profile.py
+++ b/strides_ai/profile.py
@@ -11,6 +11,7 @@ RUNNING_DEFAULTS: dict = {
         "date_of_birth": "",
         "height": "",
         "weight": "",
+        "max_hr": "",
     },
     "running_background": {
         "running_since": "",
@@ -37,6 +38,7 @@ CYCLING_DEFAULTS: dict = {
         "date_of_birth": "",
         "height": "",
         "weight": "",
+        "max_hr": "",
     },
     "cycling_background": {
         "cycling_since": "",
@@ -63,6 +65,7 @@ HYBRID_DEFAULTS: dict = {
         "date_of_birth": "",
         "height": "",
         "weight": "",
+        "max_hr": "",
     },
     "running_background": {
         "running_since": "",
@@ -134,6 +137,7 @@ def profile_to_text(fields: dict | None, mode: str) -> str:
         f"Date of birth: {_v(p.get('date_of_birth'))}" if _v(p.get("date_of_birth")) else "",
         f"Height: {_v(p.get('height'))}" if _v(p.get("height")) else "",
         f"Weight: {_v(p.get('weight'))}" if _v(p.get("weight")) else "",
+        f"Max heart rate: {_v(p.get('max_hr'))} bpm" if _v(p.get("max_hr")) else "",
     ]
     s = _section("Personal", personal_lines)
     if s:

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -364,6 +364,7 @@ export default function Profile({ mode, theme }: Props) {
               <Field label="Date of birth" value={fields.personal?.date_of_birth ?? ""} onChange={(v) => setNested("personal", "date_of_birth", v)} placeholder="e.g. 1990-05-15" focusClass={focusClass} />
               <Field label="Height" value={fields.personal?.height ?? ""} onChange={(v) => setNested("personal", "height", v)} placeholder="e.g. 175 cm" focusClass={focusClass} />
               <Field label="Weight" value={fields.personal?.weight ?? ""} onChange={(v) => setNested("personal", "weight", v)} placeholder="e.g. 70 kg" focusClass={focusClass} />
+              <Field label="Max heart rate" value={fields.personal?.max_hr ?? ""} onChange={(v) => setNested("personal", "max_hr", v)} placeholder="e.g. 185" focusClass={focusClass} />
             </div>
           </Section>
 


### PR DESCRIPTION
## Summary

- `max_hr` was silently defaulting to `190` in the `settings` table with no way to change it through the UI
- Added `max_hr` to the `personal` section of all three profile schemas (`running`, `cycling`, `hybrid`)
- Value is rendered in the LLM system prompt as `Max heart rate: N bpm` so the coach is aware of it
- On profile save (`PUT /api/profile`), the value is synced to the `settings` table so the next Strava sync uses the correct value when computing HR zones (Z1–Z5)

## Data flow

```
User sets max_hr = 178 in profile UI
  → PUT /api/profile
  → profiles table updated (max_hr stored in personal JSON)
  → settings table updated (key="max_hr", value="178")
  → LLM system prompt rebuilt → "Max heart rate: 178 bpm"

Next Strava sync:
  → sync.py reads get_setting("max_hr") → "178"
  → _hr_zones() uses 178 as Z5 ceiling for new activities
```

## Notes

- Clearing the field or entering non-numeric text leaves the `settings` value untouched (`.isdigit()` guard)
- Existing activity zone data remains as-is until a re-sync — no re-analysis logic added
- No DB migration needed

## Test plan

- [x] Profile UI shows a new "Max heart rate" field under Personal
- [x] Save with a value → `settings` table has `key="max_hr"` with the correct value
- [x] Save with blank → `settings` value unchanged
- [x] Chat confirms system prompt includes "Max heart rate: N bpm"
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)