### PR TITLE
refactor(profile): share personal section across all modes

### DIFF
--- a/strides_ai/api/routers/profile.py
+++ b/strides_ai/api/routers/profile.py
@@ -51,7 +51,10 @@ def reset_profile(
     session: Session = Depends(get_session),
 ):
     m = mode or request.app.state.mode
-    fields = get_default_fields(m)
-    crud.save_fields(session, m, fields)
+    defaults = get_default_fields(m)
+    mode_defaults = {k: v for k, v in defaults.items() if k != "personal"}
+    current = crud.get_fields(session, m) or {}
+    merged = {**mode_defaults, "personal": current.get("personal", {})}
+    crud.save_fields(session, m, merged)
     init_backend(request.app)
-    return {"fields": fields}
+    return {"fields": merged}

--- a/strides_ai/db/profiles.py
+++ b/strides_ai/db/profiles.py
@@ -10,16 +10,29 @@ from .models import Profile
 
 
 def get_fields(session: Session, mode: str) -> dict | None:
-    """Return the profile fields dict for the given mode, or None if not saved."""
-    row = session.get(Profile, mode)
-    return json.loads(row.fields_json) if row else None
+    """Return the profile fields dict for the given mode merged with shared personal data.
+
+    Personal info (name, gender, etc.) is stored once under mode="personal" and merged
+    into every mode's fields so the athlete only needs to fill it in once.
+    """
+    personal_row = session.get(Profile, "personal")
+    mode_row = session.get(Profile, mode)
+    personal = json.loads(personal_row.fields_json) if personal_row else {}
+    mode_data = json.loads(mode_row.fields_json) if mode_row else {}
+    if not personal and not mode_data:
+        return None
+    return {**mode_data, "personal": personal}
 
 
 def save_fields(session: Session, mode: str, fields: dict) -> None:
-    stmt = sqlite_insert(Profile).values(mode=mode, fields_json=json.dumps(fields))
-    stmt = stmt.on_conflict_do_update(
-        index_elements=["mode"],
-        set_={"fields_json": json.dumps(fields), "updated_at": sa.text("datetime('now')")},
-    )
-    session.execute(stmt)
+    """Save profile fields, storing personal data shared across all modes separately."""
+    personal = fields.get("personal", {})
+    mode_data = {k: v for k, v in fields.items() if k != "personal"}
+    for row_mode, data in [("personal", personal), (mode, mode_data)]:
+        stmt = sqlite_insert(Profile).values(mode=row_mode, fields_json=json.dumps(data))
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["mode"],
+            set_={"fields_json": json.dumps(data), "updated_at": sa.text("datetime('now')")},
+        )
+        session.execute(stmt)
     session.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -234,11 +234,15 @@ def test_save_and_get_profile_fields(tmp_db):
     assert result["goals"] == "sub-3"
 
 
-def test_profile_fields_isolated_per_mode(tmp_db):
-    db.save_profile_fields("running", {"personal": {"name": "Runner"}})
-    db.save_profile_fields("cycling", {"personal": {"name": "Cyclist"}})
-    assert db.get_profile_fields("running")["personal"]["name"] == "Runner"
+def test_personal_section_shared_across_modes(tmp_db):
+    # personal is shared — last write wins regardless of mode
+    db.save_profile_fields("running", {"personal": {"name": "Runner"}, "goals": "sub-3"})
+    db.save_profile_fields("cycling", {"personal": {"name": "Cyclist"}, "goals": "century"})
+    assert db.get_profile_fields("running")["personal"]["name"] == "Cyclist"
     assert db.get_profile_fields("cycling")["personal"]["name"] == "Cyclist"
+    # mode-specific fields remain isolated
+    assert db.get_profile_fields("running")["goals"] == "sub-3"
+    assert db.get_profile_fields("cycling")["goals"] == "century"
 
 
 def test_save_profile_fields_replaces_existing(tmp_db):


### PR DESCRIPTION
## Summary

- The `personal` section (name, gender, DOB, height, weight, max_hr) is now stored **once** and shared across all modes (running, cycling, hybrid)
- Previously each mode had a fully independent profile blob — changing your name in running mode had no effect on cycling
- No DB migration needed: uses a new `mode="personal"` row in the existing `profiles` table

## How it works

`get_fields(mode)` merges the shared personal row with the mode-specific row before returning. `save_fields(mode, fields)` splits personal out and upserts both rows independently. Everything above this layer (API, `profile_to_text()`, frontend) is unchanged.

```
GET /api/profile?mode=cycling
  → personal row (mode="personal") + cycling row merged → returned as one dict

PUT /api/profile?mode=running  {personal: {name: "Bob"}, running_background: {...}}
  → personal saved to mode="personal" row  ← shared across all modes
  → running fields saved to mode="running" row  ← mode-specific only
```

`reset_profile` now resets only mode-specific fields — personal is preserved.

## Note for existing users

The first load after deploy will show blank personal fields (the new `mode="personal"` row doesn't exist yet). Enter the info once and it propagates to all modes.

## Test plan

- [x] Set name in running → switch to cycling → name pre-filled ✓
- [x] Edit cycling background → personal unchanged ✓  
- [x] Reset running profile → personal preserved, running fields cleared ✓
- [x] `make test` passes (263 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)