### PR TITLE
feat(calendar): weekly planned and actual distance totals

### DIFF
--- a/web/src/pages/Calendar.tsx
+++ b/web/src/pages/Calendar.tsx
@@ -92,7 +92,7 @@ const RUN_TYPES = new Set(["Run", "TrailRun", "VirtualRun"]);
 
 export default function Calendar() {
   const today = new Date();
-  const todayStr = today.toISOString().slice(0, 10);
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
 
   const [currentMonth, setCurrentMonth] = useState(
     new Date(today.getFullYear(), today.getMonth(), 1)


### PR DESCRIPTION
## Summary

- Adds a weekly totals column to the right of each calendar week row showing **Planned** and **Actual** distance (km)
- Planned total sums `distance_km` across non-Rest workouts for the week
- Actual total sums `distance_m` from Strava activities for the week, shown in green when present
- Also fixes a bug where today's date was highlighted using UTC time instead of local time, causing the wrong day to be highlighted for users in negative UTC offsets

## Test plan

- [ ] Weekly totals column appears to the right of each week row
- [ ] Planned total reflects scheduled workout distances
- [ ] Actual total reflects completed Strava activities
- [ ] Today's date is correctly highlighted using local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)