### PR TITLE
fix(calendar): use local date for today highlight instead of UTC

### DIFF
--- a/web/src/pages/Calendar.tsx
+++ b/web/src/pages/Calendar.tsx
@@ -92,7 +92,7 @@ const RUN_TYPES = new Set(["Run", "TrailRun", "VirtualRun"]);
 
 export default function Calendar() {
   const today = new Date();
-  const todayStr = today.toISOString().slice(0, 10);
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
 
   const [currentMonth, setCurrentMonth] = useState(
     new Date(today.getFullYear(), today.getMonth(), 1)


### PR DESCRIPTION
## Summary

`toISOString()` converts to UTC before formatting, so users in negative UTC offsets (e.g. US timezones) see tomorrow's date highlighted as "today" in the evening.

Fixed by building the date string from `getFullYear`/`getMonth`/`getDate`, which read from the browser's local timezone.

## Test plan

- [x] Today's date is correctly highlighted using local time, not UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)