### PR TITLE
feat(coach): inject current date and time into system prompt

### DIFF
--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -1,6 +1,7 @@
 """Coaching system prompt assembly and history utilities."""
 
 import sqlite3
+from datetime import datetime
 
 from .db import RUN_TYPES
 from . import db
@@ -96,6 +97,17 @@ def build_system(
     activities: list | None = None,
 ) -> str:
     prompt = _PROMPT_BY_MODE.get(mode, RUNNING_SYSTEM_PROMPT)
+
+    now = datetime.now().astimezone()
+    day_str = now.strftime("%A, %B %-d, %Y")
+    time_str = now.strftime("%-I:%M %p %Z")
+    prompt += (
+        f"\n\n## Current Date & Time\n"
+        f"Today is {day_str} at {time_str}. "
+        "Use this to reason about training timing, upcoming workouts, recovery windows, "
+        "and time elapsed since past activities. "
+        "Do not mention the date or time in responses unless directly relevant to the athlete's question."
+    )
 
     if profile:
         prompt += f"\n\n{profile}"


### PR DESCRIPTION
## Summary
- Adds a `## Current Date & Time` block to the system prompt on every chat request, giving the model an explicit temporal anchor
- Uses `datetime.now().astimezone()` to respect the server's local timezone (avoids UTC mismatch on WSL/Linux)
- Includes a prompt instruction to use the date silently for internal reasoning rather than surfacing it unprompted — so the model can say "your race is in 8 days" when relevant without starting every response with "As of today..."

## Test plan
- [ ] Ask "How am I doing this week?" — model should reference recent activity recency without volunteering today's date
- [ ] Ask "When is my next hard workout?" — model should compute days from today correctly
- [ ] Ask "What day is it?" — only then should the date appear explicitly in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)