### PR TITLE
feat(lifting): HEVY integration and lifting coaching mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@
 STRAVA_CLIENT_ID=your_client_id
 STRAVA_CLIENT_SECRET=your_client_secret
 
+# ── HEVY (weightlifting) ──────────────────────────────────────────────────────
+# Required for lifting mode. Requires a Hevy Pro subscription.
+# Get your key at https://hevy.com/settings?developer
+# HEVY_API_KEY=your_hevy_api_key
+
 # ── LLM provider ─────────────────────────────────────────────────────────────
 # Set PROVIDER to "claude" (default), "gemini", or "ollama"
 PROVIDER=claude

--- a/alembic/versions/005_hevy_columns.py
+++ b/alembic/versions/005_hevy_columns.py
@@ -1,0 +1,30 @@
+"""Add HEVY-specific columns to activities table.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-04-24
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "005"
+down_revision = "004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.add_column(sa.Column("hevy_workout_id", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("exercises_json", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("total_volume_kg", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("total_sets", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.drop_column("total_sets")
+        batch_op.drop_column("total_volume_kg")
+        batch_op.drop_column("exercises_json")
+        batch_op.drop_column("hevy_workout_id")

--- a/strides_ai/api/app.py
+++ b/strides_ai/api/app.py
@@ -15,6 +15,7 @@ from .routers import (
     calendar,
     charts,
     chat,
+    hevy,
     history,
     memories,
     profile,
@@ -51,6 +52,7 @@ app.include_router(charts.router, prefix="/api")
 app.include_router(memories.router, prefix="/api")
 app.include_router(profile.router, prefix="/api")
 app.include_router(sync.router, prefix="/api")
+app.include_router(hevy.router, prefix="/api")
 app.include_router(history.router, prefix="/api")
 app.include_router(analysis.router, prefix="/api")
 app.include_router(calendar.router, prefix="/api")

--- a/strides_ai/api/routers/analysis.py
+++ b/strides_ai/api/routers/analysis.py
@@ -1,6 +1,7 @@
 """Deep-dive analysis endpoint."""
 
 import asyncio
+import json
 import logging
 from datetime import datetime, timezone
 
@@ -21,6 +22,7 @@ from ...config import get_settings
 from ...db import activities as crud
 from ...db import get_all_memories, get_profile_fields
 from ...db.engine import get_session
+from ...hevy_analysis import LIFTING_DEEP_DIVE_SYSTEM_PROMPT
 from ...profile import profile_to_text
 from ..deps import get_backend
 
@@ -79,6 +81,79 @@ async def deep_dive(
             model=activity.deep_dive_model,
         )
 
+    activity_dict = activity.model_dump()
+    mode = getattr(request.app.state, "mode", "running")
+
+    # ── Lifting (HEVY) deep dive — no Strava streams needed ──────────────
+    if activity.sport_type == "WeightTraining":
+        if not activity.exercises_json:
+            raise HTTPException(
+                status_code=422, detail="No exercise data available for this session"
+            )
+
+        system_prompt = LIFTING_DEEP_DIVE_SYSTEM_PROMPT
+        try:
+            exercises = json.loads(activity.exercises_json)
+        except Exception:
+            raise HTTPException(status_code=422, detail="Could not parse exercise data")
+
+        lines = [f"Workout: {activity.name or 'Weight Training'}  |  Date: {activity.date}"]
+        if activity.total_volume_kg:
+            lines.append(
+                f"Total volume: {activity.total_volume_kg:.0f} kg  |  Sets: {activity.total_sets or '?'}"
+            )
+        lines.append("")
+        for ex in exercises:
+            lines.append(f"### {ex.get('title') or ex.get('name', 'Exercise')}")
+            for s in ex.get("sets", []):
+                weight = f"{s['weight_kg']} kg" if s.get("weight_kg") is not None else "BW"
+                reps = f"x{s['reps']}" if s.get("reps") is not None else ""
+                rpe = f"  RPE {s['rpe']}" if s.get("rpe") is not None else ""
+                stype = f"[{s['type']}]" if s.get("type") and s["type"] != "normal" else ""
+                lines.append(f"  {stype} {weight} {reps}{rpe}".strip())
+            lines.append("")
+        user_content = "\n".join(lines)
+
+        profile_text = profile_to_text(get_profile_fields(mode), mode)
+        if profile_text:
+            system_prompt += f"\n\n{profile_text}"
+
+        memories = get_all_memories()
+        if memories:
+            mem_lines = "\n".join(f"  [{m['category']}] {m['content']}" for m in memories)
+            system_prompt += (
+                f"\n\n## Coaching Notes (remembered from previous sessions)\n{mem_lines}"
+            )
+
+        def _run_llm_lifting():
+            return backend.stateless_turn(system_prompt, user_content, on_token=lambda _: None)
+
+        try:
+            report = await asyncio.get_event_loop().run_in_executor(None, _run_llm_lifting)
+        except Exception as exc:
+            log.error("LLM deep dive failed for lifting session %s: %s", activity_id, exc)
+            raise HTTPException(status_code=500, detail="LLM analysis failed")
+
+        completed_at = datetime.now(timezone.utc).isoformat()
+        model_label = backend.label
+        crud.update_analysis(
+            session,
+            activity_id,
+            {
+                "deep_dive_report": report,
+                "deep_dive_completed_at": completed_at,
+                "deep_dive_model": model_label,
+            },
+        )
+        return DeepDiveResponse(
+            activity_id=activity_id,
+            report=report,
+            cached=False,
+            completed_at=completed_at,
+            model=model_label,
+        )
+
+    # ── Cardio (Strava) deep dive ─────────────────────────────────────────
     settings = get_settings()
     if not settings.strava_client_id or not settings.strava_client_secret:
         raise HTTPException(status_code=500, detail="Strava credentials not configured")
@@ -100,9 +175,6 @@ async def deep_dive(
             status_code=422,
             detail="No stream data available for this activity (manual entry or GPS disabled)",
         )
-
-    activity_dict = activity.model_dump()
-    mode = getattr(request.app.state, "mode", "running")
 
     if backend.prefers_precomputed_brief:
         system_prompt = DEEP_DIVE_SYSTEM_PROMPT_LOCAL

--- a/strides_ai/api/routers/hevy.py
+++ b/strides_ai/api/routers/hevy.py
@@ -1,0 +1,21 @@
+"""HEVY sync routes."""
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ...config import get_settings
+from ...hevy_sync import sync_hevy_workouts
+from ..deps import init_backend
+
+router = APIRouter()
+
+
+@router.post("/hevy/sync")
+def hevy_sync(request: Request, full: bool = False):
+    settings = get_settings()
+    if not settings.hevy_api_key:
+        raise HTTPException(status_code=500, detail="HEVY_API_KEY not configured")
+
+    new_count = sync_hevy_workouts(full=full)
+    if new_count > 0:
+        init_backend(request.app)
+    return {"new_workouts": new_count}

--- a/strides_ai/auth.py
+++ b/strides_ai/auth.py
@@ -10,7 +10,9 @@ from urllib.parse import urlparse, parse_qs, urlencode
 
 import httpx
 
-TOKEN_FILE = Path.home() / ".strides_ai" / "token.json"
+from strides_ai.config import DATA_DIR
+
+TOKEN_FILE = DATA_DIR / "token.json"
 AUTH_URL = "https://www.strava.com/oauth/authorize"
 TOKEN_URL = "https://www.strava.com/oauth/token"
 REDIRECT_PORT = 8282

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -3,7 +3,7 @@
 import sqlite3
 from datetime import datetime
 
-from .db import RUN_TYPES
+from .db import RUN_TYPES, LIFT_TYPES
 from . import db
 
 RECALL_MESSAGES = 40
@@ -83,10 +83,33 @@ goals, upcoming events, injuries, preferences, or any key context that should \
 persist across sessions.\
 """
 
+LIFTING_SYSTEM_PROMPT = """\
+You are an experienced, data-driven strength and conditioning coach with access to the athlete's \
+complete HEVY training log. Your role is to:
+
+- Analyse training volume, intensity, and progression from the data provided.
+- Answer questions about specific sessions, weekly volume, and strength progress.
+- Give evidence-based coaching advice: programming, progressive overload, recovery, \
+injury prevention, deload timing, and exercise selection.
+- Be concise but thorough. When referencing specific sessions, cite the date and \
+key metrics (exercises, volume, RPE, estimated 1RM).
+- Use metric units (kg) unless the athlete asks otherwise.
+- When estimating 1-rep maxes, use the Epley formula (weight × (1 + reps/30)) and \
+note it is an estimate.
+
+The athlete's complete training log is included below. Treat it as ground \
+truth for all data-related questions.
+
+**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
+goals, upcoming competitions, injuries, preferences, or any key context that should \
+persist across sessions.\
+"""
+
 _PROMPT_BY_MODE = {
     "running": RUNNING_SYSTEM_PROMPT,
     "cycling": CYCLING_SYSTEM_PROMPT,
     "hybrid": HYBRID_SYSTEM_PROMPT,
+    "lifting": LIFTING_SYSTEM_PROMPT,
 }
 
 
@@ -140,8 +163,8 @@ def build_system(
     # The full training log is seeded once in conversation history.
     recent = (activities or [])[:RECENT_ACTIVITIES_IN_SYSTEM]
 
-    # Inject metrics guide when any activity has been analyzed
-    has_analysis = any(a.get("analysis_summary") for a in recent)
+    # Inject cardio metrics guide when any activity has been analyzed (not relevant for lifting)
+    has_analysis = mode != "lifting" and any(a.get("analysis_summary") for a in recent)
     if has_analysis:
         prompt += (
             "\n\n## Analysis Metrics Guide\n"
@@ -193,6 +216,26 @@ def _format_duration(seconds: int | None) -> str:
 def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
     if not rows:
         return "No activities found."
+
+    if mode == "lifting":
+        header = "DATE       | NAME                           | DURATION | SETS | VOLUME(kg) | RPE | ANALYSIS"
+        sep = "-" * 140
+        lines = [header, sep]
+        for r in reversed(rows):
+            analysis = (r.get("analysis_summary") or "")[:60]
+            lines.append(
+                f"{r['date'] or '?':10s} | "
+                f"{(r['name'] or '')[:30]:30s} | "
+                f"{_format_duration(r['moving_time_s']):8s} | "
+                f"{r['total_sets'] or '—':4} | "
+                f"{r['total_volume_kg'] or '—':10} | "
+                f"{r['perceived_exertion'] or '—':3} | "
+                f"{analysis}"
+            )
+        total_volume = sum((r["total_volume_kg"] or 0) for r in rows)
+        lines.append(sep)
+        lines.append(f"Total: {len(rows)} sessions, {total_volume:.0f} kg cumulative volume")
+        return "\n".join(lines)
 
     if mode == "hybrid":
         header = "DATE       | TYPE       | NAME                           | DIST(km) | DURATION | PACE/SPEED  | AVG HR | MAX HR | CADENCE | ELEV(m) | SUFFER | RPE | ANALYSIS"
@@ -285,7 +328,11 @@ def build_initial_history(
     only the oldest runs are dropped — recent ones are protected by the system prompt.
     """
     training_log = build_training_log(activities, mode)
-    act_label = "runs" if mode == "running" else "rides" if mode == "cycling" else "activities"
+    act_label = (
+        "runs"
+        if mode == "running"
+        else "rides" if mode == "cycling" else "sessions" if mode == "lifting" else "activities"
+    )
     log_message = f"Here is the athlete's complete training log:\n\n```\n{training_log}\n```"
     return [
         {"role": "user", "content": log_message},

--- a/strides_ai/config.py
+++ b/strides_ai/config.py
@@ -1,5 +1,6 @@
 """Application-wide configuration and constants."""
 
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -22,6 +23,9 @@ class Settings(BaseSettings):
     strava_client_id: str = ""
     strava_client_secret: str = ""
 
+    # HEVY
+    hevy_api_key: str = ""
+
     # Server
     port: int = 8000
 
@@ -33,9 +37,14 @@ def get_settings() -> Settings:
 
 # ── Application constants ──────────────────────────────────────────────────────
 
-VALID_MODES: frozenset[str] = frozenset({"running", "cycling", "hybrid"})
+VALID_MODES: frozenset[str] = frozenset({"running", "cycling", "hybrid", "lifting"})
 VALID_PROVIDERS: frozenset[str] = frozenset({"claude", "gemini", "ollama", "openai"})
 
-UPLOADS_DIR = Path.home() / ".strides_ai" / "uploads"
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATA_DIR = Path(os.environ.get("STRIDES_DATA_DIR", Path.home() / ".strides_ai")).expanduser()
+UPLOADS_DIR = DATA_DIR / "uploads"
 SUPPORTED_IMAGE_TYPES = frozenset({"image/jpeg", "image/png", "image/gif", "image/webp"})
 MAX_FILE_BYTES = 20 * 1024 * 1024  # 20 MB

--- a/strides_ai/db/__init__.py
+++ b/strides_ai/db/__init__.py
@@ -18,6 +18,7 @@ from .models import (
     Setting,
     TrainingPlan,
     CYCLE_TYPES,
+    LIFT_TYPES,
     RUN_TYPES,
 )
 from . import activities as _act
@@ -48,11 +49,14 @@ __all__ = [
     "Setting",
     "TrainingPlan",
     "CYCLE_TYPES",
+    "LIFT_TYPES",
     "RUN_TYPES",
     # convenience wrappers (see below)
     "get_latest_activity_date",
+    "get_latest_hevy_date",
     "get_stored_ids",
     "upsert_activity",
+    "upsert_hevy_workout",
     "get_all_activities",
     "get_activities_for_mode",
     "get_activity",
@@ -99,6 +103,19 @@ def get_latest_activity_date() -> str | None:
         return _act.get_latest_activity_date(s)
 
 
+def get_latest_hevy_date() -> str | None:
+    """Return the date of the most recent WeightTraining activity, or None."""
+    with _session() as s:
+        from .models import Activity
+        import sqlalchemy as sa
+        from sqlmodel import select
+
+        result = s.execute(
+            select(sa.func.max(Activity.date)).where(Activity.sport_type == "WeightTraining")
+        ).scalar()
+        return result
+
+
 def get_stored_ids() -> set[int]:
     with _session() as s:
         return _act.get_stored_ids(s)
@@ -107,6 +124,11 @@ def get_stored_ids() -> set[int]:
 def upsert_activity(activity: dict) -> None:
     with _session() as s:
         _act.upsert(s, activity)
+
+
+def upsert_hevy_workout(activity: dict) -> None:
+    with _session() as s:
+        _act.upsert_hevy(s, activity)
 
 
 def get_all_activities() -> list[dict]:

--- a/strides_ai/db/activities.py
+++ b/strides_ai/db/activities.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlmodel import Session, select
 
-from .models import Activity, RUN_TYPES, CYCLE_TYPES
+from .models import Activity, RUN_TYPES, CYCLE_TYPES, LIFT_TYPES
 
 
 def get_latest_activity_date(session: Session) -> str | None:
@@ -62,6 +62,39 @@ def upsert(session: Session, activity: dict[str, Any]) -> None:
     session.commit()
 
 
+def upsert_hevy(session: Session, activity: dict[str, Any]) -> None:
+    """Insert or replace an activity row derived from a HEVY workout."""
+    values = {
+        "id": activity["id"],
+        "name": activity.get("name"),
+        "date": activity.get("date"),
+        "distance_m": None,
+        "moving_time_s": activity.get("moving_time_s"),
+        "elapsed_time_s": activity.get("elapsed_time_s"),
+        "elevation_gain_m": None,
+        "avg_pace_s_per_km": None,
+        "avg_hr": None,
+        "max_hr": None,
+        "avg_cadence": None,
+        "suffer_score": None,
+        "perceived_exertion": activity.get("perceived_exertion"),
+        "sport_type": "WeightTraining",
+        "raw_json": activity.get("raw_json"),
+        "hevy_workout_id": activity.get("hevy_workout_id"),
+        "exercises_json": activity.get("exercises_json"),
+        "total_volume_kg": activity.get("total_volume_kg"),
+        "total_sets": activity.get("total_sets"),
+    }
+
+    stmt = sqlite_insert(Activity).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["id"],
+        set_={k: v for k, v in values.items() if k != "id"},
+    )
+    session.execute(stmt)
+    session.commit()
+
+
 def get_all(session: Session) -> list[Activity]:
     """Return all activities ordered newest-first."""
     return session.exec(select(Activity).order_by(Activity.date.desc())).all()
@@ -79,6 +112,12 @@ def get_for_mode(session: Session, mode: str) -> list[Activity]:
         stmt = (
             select(Activity)
             .where(Activity.sport_type.in_(CYCLE_TYPES))
+            .order_by(Activity.date.desc())
+        )
+    elif mode == "lifting":
+        stmt = (
+            select(Activity)
+            .where(Activity.sport_type.in_(LIFT_TYPES))
             .order_by(Activity.date.desc())
         )
     else:  # hybrid

--- a/strides_ai/db/engine.py
+++ b/strides_ai/db/engine.py
@@ -6,7 +6,9 @@ from typing import Generator
 import sqlalchemy as sa
 from sqlmodel import Session, create_engine
 
-DB_PATH = Path.home() / ".strides_ai" / "activities.db"
+from strides_ai.config import DATA_DIR
+
+DB_PATH = DATA_DIR / "activities.db"
 
 _engine: sa.engine.Engine | None = None
 

--- a/strides_ai/db/models.py
+++ b/strides_ai/db/models.py
@@ -8,6 +8,7 @@ from sqlmodel import Column, Field, SQLModel
 # Activity type sets — used by sync.py and query filters
 RUN_TYPES = {"Run", "TrailRun", "VirtualRun"}
 CYCLE_TYPES = {"Ride", "VirtualRide", "GravelRide"}
+LIFT_TYPES = {"WeightTraining"}
 
 
 class Activity(SQLModel, table=True):
@@ -49,6 +50,12 @@ class Activity(SQLModel, table=True):
     deep_dive_model: Optional[str] = None
     analysis_status: Optional[str] = None
     user_notes: Optional[str] = None
+
+    # HEVY (weightlifting) columns
+    hevy_workout_id: Optional[str] = None
+    exercises_json: Optional[str] = None
+    total_volume_kg: Optional[float] = None
+    total_sets: Optional[int] = None
 
 
 class Conversation(SQLModel, table=True):

--- a/strides_ai/hevy_analysis.py
+++ b/strides_ai/hevy_analysis.py
@@ -1,0 +1,164 @@
+"""Analysis pipeline for HEVY (weightlifting) workouts."""
+
+import json
+import logging
+from collections import defaultdict
+
+log = logging.getLogger(__name__)
+
+# Epley 1RM formula: weight * (1 + reps / 30)
+# Only meaningful for sets with reps <= 12 (higher rep sets yield unreliable estimates)
+_EPLEY_MAX_REPS = 12
+
+
+def estimate_1rm(weight_kg: float, reps: int) -> float | None:
+    """Epley 1RM estimate. Returns None for invalid inputs."""
+    if weight_kg <= 0 or reps <= 0 or reps > _EPLEY_MAX_REPS:
+        return None
+    return round(weight_kg * (1 + reps / 30), 1)
+
+
+def compute_hevy_metrics(exercises_json: str | None) -> dict:
+    """
+    Derive lifting metrics from the HEVY exercises JSON blob.
+
+    Returns a dict suitable for passing to db.save_analysis():
+      - total_volume_kg
+      - total_sets
+      - avg_rpe
+      - estimated_1rms: {exercise_title: best_1rm_kg}
+      - muscle_volume: {muscle_group: volume_kg}
+      - analysis_summary: human-readable NL string
+    """
+    if not exercises_json:
+        return {}
+
+    try:
+        exercises: list[dict] = json.loads(exercises_json)
+    except (json.JSONDecodeError, TypeError):
+        log.warning("could not parse exercises_json")
+        return {}
+
+    total_volume = 0.0
+    total_sets = 0
+    rpe_values: list[float] = []
+    best_1rms: dict[str, float] = {}
+    muscle_volume: dict[str, float] = defaultdict(float)
+
+    exercise_summaries: list[str] = []
+
+    for ex in exercises:
+        title = ex.get("title", "Unknown")
+        muscle = ex.get("primary_muscle_group") or "Unknown"
+        working_sets = [s for s in ex.get("sets", []) if s.get("type") != "warmup"]
+
+        ex_volume = 0.0
+        ex_sets = 0
+
+        for s in working_sets:
+            weight = s.get("weight_kg") or 0.0
+            reps = s.get("reps") or 0
+            rpe = s.get("rpe")
+
+            ex_volume += weight * reps
+            ex_sets += 1
+
+            if rpe is not None:
+                rpe_values.append(float(rpe))
+
+            one_rm = estimate_1rm(weight, reps)
+            if one_rm is not None:
+                if title not in best_1rms or one_rm > best_1rms[title]:
+                    best_1rms[title] = one_rm
+
+        total_volume += ex_volume
+        total_sets += ex_sets
+        muscle_volume[muscle] += ex_volume
+
+        if ex_sets > 0:
+            # Summarise as "Bench Press: 4×8 @ 80 kg"
+            # Use the most common rep count for brevity
+            all_reps = [s.get("reps") or 0 for s in working_sets]
+            rep_str = str(all_reps[0]) if all_reps else "?"
+            weight_vals = [s.get("weight_kg") or 0 for s in working_sets if s.get("weight_kg")]
+            weight_str = f"{max(weight_vals):.1f} kg" if weight_vals else "BW"
+            exercise_summaries.append(f"{title}: {ex_sets}×{rep_str} @ {weight_str}")
+
+    avg_rpe = round(sum(rpe_values) / len(rpe_values), 1) if rpe_values else None
+
+    # Build NL summary
+    parts: list[str] = []
+    if exercise_summaries:
+        parts.append(", ".join(exercise_summaries[:4]))
+        if len(exercise_summaries) > 4:
+            parts[-1] += f" (+{len(exercise_summaries) - 4} more)"
+    parts.append(f"{total_sets} working sets")
+    parts.append(f"{total_volume:.0f} kg total volume")
+    if avg_rpe is not None:
+        parts.append(f"avg RPE {avg_rpe}")
+
+    top_muscles = sorted(muscle_volume.items(), key=lambda x: x[1], reverse=True)[:3]
+    if top_muscles:
+        muscle_str = "/".join(m for m, _ in top_muscles if m != "Unknown")
+        if muscle_str:
+            parts.append(f"primary: {muscle_str}")
+
+    summary = " | ".join(parts)
+
+    return {
+        "total_volume_kg": round(total_volume, 2),
+        "total_sets": total_sets,
+        "avg_rpe": avg_rpe,
+        "estimated_1rms": best_1rms,
+        "muscle_volume": dict(muscle_volume),
+        "analysis_summary": summary,
+    }
+
+
+def analyze_hevy_workout(row: dict) -> None:
+    """
+    Compute metrics for a HEVY workout row and persist them.
+
+    *row* is the dict returned by hevy_sync._transform_workout().
+    Updates the activity in the DB with analysis_summary and analysis_status.
+    """
+    from . import db
+
+    activity_id = row.get("id")
+    if activity_id is None:
+        return
+
+    metrics = compute_hevy_metrics(row.get("exercises_json"))
+    if not metrics:
+        db.save_analysis(
+            activity_id, {"analysis_status": "done", "analysis_summary": "No exercise data"}
+        )
+        return
+
+    db.save_analysis(
+        activity_id,
+        {
+            "total_volume_kg": metrics["total_volume_kg"],
+            "total_sets": metrics["total_sets"],
+            "analysis_summary": metrics["analysis_summary"],
+            "analysis_status": "done",
+        },
+    )
+
+
+LIFTING_DEEP_DIVE_SYSTEM_PROMPT = """\
+You are a strength and conditioning coach performing a detailed analysis of a single weight training session.
+
+The workout data below lists each exercise with its sets, showing: set type (normal/warmup/dropset/failure), weight (kg), reps, and RPE (rate of perceived exertion, 6–10 scale) where recorded.
+
+Do not ask follow-up questions. Analyse only the data provided and write your report now.
+
+Cover each of these dimensions:
+1. **Volume and intensity**: Was the total load appropriate? How does RPE track across the session?
+2. **Exercise selection and order**: Does the sequencing make sense (compound lifts first, isolation after)?
+3. **Set quality**: Were there any sets that look like outliers — unexpectedly light, unusually heavy, or inconsistent reps?
+4. **Estimated 1RM trends**: For main compound lifts (squat, bench, deadlift, press), note the estimated 1RM.
+5. **Fatigue signs**: Did performance drop across sets within an exercise, suggesting insufficient rest or high fatigue?
+
+End with 3–5 specific, actionable coaching notes the athlete can apply to their next session.\
+"""

--- a/strides_ai/hevy_sync.py
+++ b/strides_ai/hevy_sync.py
@@ -1,0 +1,167 @@
+"""Fetch workouts from HEVY and persist them locally."""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+import httpx
+
+from . import db
+from .config import get_settings
+from .hevy_analysis import analyze_hevy_workout
+
+HEVY_API_BASE = "https://api.hevyapp.com"
+PAGE_SIZE = 10  # HEVY max page size for workouts
+
+log = logging.getLogger(__name__)
+
+
+def _get_headers() -> dict[str, str]:
+    return {"api-key": get_settings().hevy_api_key}
+
+
+def _parse_dt(iso: str | None) -> datetime | None:
+    if not iso:
+        return None
+    return datetime.fromisoformat(iso.replace("Z", "+00:00"))
+
+
+def _compute_volume(exercises: list[dict]) -> tuple[float, int]:
+    """Return (total_volume_kg, total_sets) across all exercises."""
+    volume = 0.0
+    sets = 0
+    for ex in exercises:
+        for s in ex.get("sets", []):
+            if s.get("type") == "warmup":
+                continue
+            sets += 1
+            w = s.get("weight_kg") or 0.0
+            r = s.get("reps") or 0
+            volume += w * r
+    return round(volume, 2), sets
+
+
+def _transform_workout(w: dict) -> dict:
+    """Map a HEVY workout dict → Activity-compatible row dict."""
+    start = _parse_dt(w.get("start_time"))
+    end = _parse_dt(w.get("end_time"))
+
+    moving_time_s: int | None = None
+    if start and end:
+        moving_time_s = max(0, int((end - start).total_seconds()))
+
+    exercises = w.get("exercises", [])
+    total_volume_kg, total_sets = _compute_volume(exercises)
+
+    # Use a stable integer ID derived from the HEVY UUID for the PK.
+    # We take the last 9 hex digits of the UUID and parse as int.
+    hevy_id: str = w["id"]
+    numeric_id = int(hevy_id.replace("-", "")[-9:], 16)
+
+    date_str = ""
+    if start:
+        date_str = start.astimezone(timezone.utc).strftime("%Y-%m-%d")
+
+    return {
+        "id": numeric_id,
+        "hevy_workout_id": hevy_id,
+        "name": w.get("title") or "Weight Training",
+        "date": date_str,
+        "moving_time_s": moving_time_s,
+        "elapsed_time_s": moving_time_s,
+        "perceived_exertion": None,
+        "exercises_json": json.dumps(exercises),
+        "total_volume_kg": total_volume_kg,
+        "total_sets": total_sets,
+        "raw_json": json.dumps(w),
+    }
+
+
+def _get_last_sync_timestamp() -> str | None:
+    """Return the ISO timestamp of the most recent HEVY workout in the DB."""
+    latest_date = db.get_latest_hevy_date()
+    return latest_date
+
+
+def sync_hevy_workouts(full: bool = False) -> int:
+    """
+    Sync weightlifting workouts from HEVY.
+
+    If *full* is False (default), uses /v1/workouts/events?since=<last_sync>
+    for an incremental update. If *full* is True, pages through all workouts.
+
+    Returns the number of new/updated workouts written.
+    """
+    settings = get_settings()
+    if not settings.hevy_api_key:
+        raise ValueError("HEVY_API_KEY not configured")
+
+    headers = _get_headers()
+    count = 0
+
+    since = db.get_latest_hevy_date()
+    if not full and since:
+        count = _sync_events(headers, since)
+    else:
+        count = _sync_full(headers)
+
+    return count
+
+
+def _sync_events(headers: dict, since: str | None) -> int:
+    """Incremental sync via /v1/workouts/events."""
+    params: dict = {}
+    if since:
+        params["since"] = since
+
+    count = 0
+    with httpx.Client(timeout=30) as client:
+        resp = client.get(f"{HEVY_API_BASE}/v1/workouts/events", headers=headers, params=params)
+        if resp.status_code == 404:
+            # Endpoint not available; fall back to full page sync
+            log.info("events endpoint unavailable, falling back to full sync")
+            return _sync_full(headers)
+        resp.raise_for_status()
+        data = resp.json()
+        events = data.get("workouts", data.get("events", []))
+        for event in events:
+            workout = event.get("workout")
+            if not workout:
+                continue
+            row = _transform_workout(workout)
+            db.upsert_hevy_workout(row)
+            analyze_hevy_workout(row)
+            count += 1
+
+    return count
+
+
+def _sync_full(headers: dict) -> int:
+    """Full paginated sync through all workouts."""
+    count = 0
+    page = 1
+
+    with httpx.Client(timeout=30) as client:
+        while True:
+            resp = client.get(
+                f"{HEVY_API_BASE}/v1/workouts",
+                headers=headers,
+                params={"page": page, "pageSize": PAGE_SIZE},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            workouts = data.get("workouts", [])
+            if not workouts:
+                break
+
+            for w in workouts:
+                row = _transform_workout(w)
+                db.upsert_hevy_workout(row)
+                analyze_hevy_workout(row)
+                count += 1
+
+            if page >= data.get("page_count", 1):
+                break
+            page += 1
+
+    return count

--- a/strides_ai/profile.py
+++ b/strides_ai/profile.py
@@ -96,10 +96,39 @@ HYBRID_DEFAULTS: dict = {
     "other_notes": "",
 }
 
+LIFTING_DEFAULTS: dict = {
+    "personal": {
+        "name": "",
+        "gender": "",
+        "date_of_birth": "",
+        "height": "",
+        "weight": "",
+    },
+    "lifting_background": {
+        "lifting_since": "",
+        "sessions_per_week": "",
+        "training_style": "",  # e.g. powerlifting, bodybuilding, general strength
+        "background": "",
+    },
+    "lifting_bests": {
+        "squat_1rm": "",
+        "deadlift_1rm": "",
+        "bench_press_1rm": "",
+        "overhead_press_1rm": "",
+        "other": "",
+    },
+    "goals": "",
+    "injuries_and_health": "",
+    "equipment": "",  # home gym, commercial gym, etc.
+    "nutrition_snacks": [],
+    "other_notes": "",
+}
+
 _DEFAULTS = {
     "running": RUNNING_DEFAULTS,
     "cycling": CYCLING_DEFAULTS,
     "hybrid": HYBRID_DEFAULTS,
+    "lifting": LIFTING_DEFAULTS,
 }
 
 
@@ -173,6 +202,50 @@ def profile_to_text(fields: dict | None, mode: str) -> str:
         if s:
             sections.append(s)
 
+    if mode == "lifting":
+        lb = fields.get("lifting_background", {})
+        lb_lines = [
+            f"Lifting since: {_v(lb.get('lifting_since'))}" if _v(lb.get("lifting_since")) else "",
+            (
+                f"Sessions per week: {_v(lb.get('sessions_per_week'))}"
+                if _v(lb.get("sessions_per_week"))
+                else ""
+            ),
+            (
+                f"Training style: {_v(lb.get('training_style'))}"
+                if _v(lb.get("training_style"))
+                else ""
+            ),
+            f"Background: {_v(lb.get('background'))}" if _v(lb.get("background")) else "",
+        ]
+        s = _section("Lifting Background", lb_lines)
+        if s:
+            sections.append(s)
+
+        lbests = fields.get("lifting_bests", {})
+        lbest_lines = [
+            f"Squat 1RM: {_v(lbests.get('squat_1rm'))}" if _v(lbests.get("squat_1rm")) else "",
+            (
+                f"Deadlift 1RM: {_v(lbests.get('deadlift_1rm'))}"
+                if _v(lbests.get("deadlift_1rm"))
+                else ""
+            ),
+            (
+                f"Bench press 1RM: {_v(lbests.get('bench_press_1rm'))}"
+                if _v(lbests.get("bench_press_1rm"))
+                else ""
+            ),
+            (
+                f"Overhead press 1RM: {_v(lbests.get('overhead_press_1rm'))}"
+                if _v(lbests.get("overhead_press_1rm"))
+                else ""
+            ),
+            f"Other: {_v(lbests.get('other'))}" if _v(lbests.get("other")) else "",
+        ]
+        s = _section("Lifting Bests", lbest_lines)
+        if s:
+            sections.append(s)
+
     if mode in ("cycling", "hybrid"):
         cb = fields.get("cycling_background", {})
         cb_lines = [
@@ -211,6 +284,7 @@ def profile_to_text(fields: dict | None, mode: str) -> str:
         ("goals", "Goals"),
         ("injuries_and_health", "Injuries & Health"),
         ("gear", "Gear"),
+        ("equipment", "Equipment"),
         ("other_notes", "Other Notes"),
     ]:
         val = _v(fields.get(key))

--- a/tests/test_hevy.py
+++ b/tests/test_hevy.py
@@ -1,0 +1,242 @@
+"""Unit tests for HEVY sync transform and analysis metrics."""
+
+import json
+
+import pytest
+
+from strides_ai.hevy_analysis import compute_hevy_metrics, estimate_1rm
+from strides_ai.hevy_sync import _compute_volume, _transform_workout
+
+
+# ── estimate_1rm ──────────────────────────────────────────────────────────────
+
+
+def test_estimate_1rm_basic():
+    # 100 kg × 5 reps: 100 * (1 + 5/30) = 116.7
+    result = estimate_1rm(100.0, 5)
+    assert result == pytest.approx(116.7, abs=0.1)
+
+
+def test_estimate_1rm_single_rep():
+    # 1 rep = the weight itself (approximately)
+    result = estimate_1rm(140.0, 1)
+    assert result == pytest.approx(140.0 * (1 + 1 / 30), abs=0.1)
+
+
+def test_estimate_1rm_zero_weight_returns_none():
+    assert estimate_1rm(0.0, 5) is None
+
+
+def test_estimate_1rm_zero_reps_returns_none():
+    assert estimate_1rm(100.0, 0) is None
+
+
+def test_estimate_1rm_high_reps_returns_none():
+    # More than 12 reps is unreliable
+    assert estimate_1rm(60.0, 15) is None
+
+
+def test_estimate_1rm_exactly_12_reps():
+    # 12 reps should still return a value
+    result = estimate_1rm(80.0, 12)
+    assert result is not None
+
+
+# ── _compute_volume ───────────────────────────────────────────────────────────
+
+
+def test_compute_volume_basic():
+    exercises = [
+        {
+            "sets": [
+                {"type": "normal", "weight_kg": 100.0, "reps": 5},
+                {"type": "normal", "weight_kg": 100.0, "reps": 5},
+                {"type": "normal", "weight_kg": 100.0, "reps": 5},
+            ]
+        }
+    ]
+    volume, sets = _compute_volume(exercises)
+    assert volume == pytest.approx(1500.0)
+    assert sets == 3
+
+
+def test_compute_volume_skips_warmup():
+    exercises = [
+        {
+            "sets": [
+                {"type": "warmup", "weight_kg": 60.0, "reps": 10},
+                {"type": "normal", "weight_kg": 100.0, "reps": 5},
+            ]
+        }
+    ]
+    volume, sets = _compute_volume(exercises)
+    assert volume == pytest.approx(500.0)
+    assert sets == 1
+
+
+def test_compute_volume_handles_missing_weight():
+    exercises = [
+        {
+            "sets": [
+                {"type": "normal", "weight_kg": None, "reps": 10},  # bodyweight
+            ]
+        }
+    ]
+    volume, sets = _compute_volume(exercises)
+    assert volume == pytest.approx(0.0)
+    assert sets == 1
+
+
+def test_compute_volume_multiple_exercises():
+    exercises = [
+        {"sets": [{"type": "normal", "weight_kg": 100.0, "reps": 5}]},
+        {"sets": [{"type": "normal", "weight_kg": 80.0, "reps": 8}]},
+    ]
+    volume, sets = _compute_volume(exercises)
+    assert volume == pytest.approx(100 * 5 + 80 * 8)
+    assert sets == 2
+
+
+# ── _transform_workout ────────────────────────────────────────────────────────
+
+
+_SAMPLE_WORKOUT = {
+    "id": "aabbccdd-1234-5678-abcd-ef0123456789",
+    "title": "Push Day",
+    "start_time": "2026-04-20T09:00:00Z",
+    "end_time": "2026-04-20T10:30:00Z",
+    "exercises": [
+        {
+            "title": "Bench Press",
+            "primary_muscle_group": "Chest",
+            "sets": [
+                {"type": "warmup", "weight_kg": 60.0, "reps": 10, "rpe": None},
+                {"type": "normal", "weight_kg": 100.0, "reps": 5, "rpe": 8.0},
+                {"type": "normal", "weight_kg": 100.0, "reps": 5, "rpe": 8.5},
+            ],
+        }
+    ],
+}
+
+
+def test_transform_workout_sport_type():
+    row = _transform_workout(_SAMPLE_WORKOUT)
+    # sport_type is set in upsert_hevy, not transform — check exercises_json present
+    assert row["exercises_json"] is not None
+
+
+def test_transform_workout_date():
+    row = _transform_workout(_SAMPLE_WORKOUT)
+    assert row["date"] == "2026-04-20"
+
+
+def test_transform_workout_name():
+    row = _transform_workout(_SAMPLE_WORKOUT)
+    assert row["name"] == "Push Day"
+
+
+def test_transform_workout_duration():
+    row = _transform_workout(_SAMPLE_WORKOUT)
+    # 90 minutes = 5400 seconds
+    assert row["moving_time_s"] == 5400
+
+
+def test_transform_workout_hevy_workout_id():
+    row = _transform_workout(_SAMPLE_WORKOUT)
+    assert row["hevy_workout_id"] == _SAMPLE_WORKOUT["id"]
+
+
+def test_transform_workout_volume():
+    row = _transform_workout(_SAMPLE_WORKOUT)
+    # 2 normal sets × 5 reps × 100 kg = 1000 kg (warmup excluded)
+    assert row["total_volume_kg"] == pytest.approx(1000.0)
+
+
+def test_transform_workout_sets():
+    row = _transform_workout(_SAMPLE_WORKOUT)
+    assert row["total_sets"] == 2  # warmup excluded
+
+
+def test_transform_workout_stable_id():
+    row1 = _transform_workout(_SAMPLE_WORKOUT)
+    row2 = _transform_workout(_SAMPLE_WORKOUT)
+    assert row1["id"] == row2["id"]
+
+
+# ── compute_hevy_metrics ──────────────────────────────────────────────────────
+
+
+def _make_exercises_json(**overrides):
+    exercises = [
+        {
+            "title": "Squat",
+            "primary_muscle_group": "Quads",
+            "sets": [
+                {"type": "warmup", "weight_kg": 60.0, "reps": 8, "rpe": None},
+                {"type": "normal", "weight_kg": 120.0, "reps": 5, "rpe": 8.0},
+                {"type": "normal", "weight_kg": 120.0, "reps": 5, "rpe": 8.5},
+                {"type": "normal", "weight_kg": 120.0, "reps": 4, "rpe": 9.0},
+            ],
+        }
+    ]
+    return json.dumps(exercises)
+
+
+def test_compute_hevy_metrics_volume():
+    metrics = compute_hevy_metrics(_make_exercises_json())
+    # 3 normal sets: 5×120 + 5×120 + 4×120 = 1680 kg
+    assert metrics["total_volume_kg"] == pytest.approx(1680.0)
+
+
+def test_compute_hevy_metrics_sets():
+    metrics = compute_hevy_metrics(_make_exercises_json())
+    assert metrics["total_sets"] == 3
+
+
+def test_compute_hevy_metrics_avg_rpe():
+    metrics = compute_hevy_metrics(_make_exercises_json())
+    # avg of 8.0, 8.5, 9.0 = 8.5
+    assert metrics["avg_rpe"] == pytest.approx(8.5)
+
+
+def test_compute_hevy_metrics_1rm_estimate():
+    metrics = compute_hevy_metrics(_make_exercises_json())
+    assert "Squat" in metrics["estimated_1rms"]
+    # Best 1RM from 5 reps @ 120 kg: 120 * (1 + 5/30) = 140.0
+    assert metrics["estimated_1rms"]["Squat"] == pytest.approx(140.0)
+
+
+def test_compute_hevy_metrics_muscle_volume():
+    metrics = compute_hevy_metrics(_make_exercises_json())
+    assert "Quads" in metrics["muscle_volume"]
+
+
+def test_compute_hevy_metrics_summary_contains_sets():
+    metrics = compute_hevy_metrics(_make_exercises_json())
+    assert "working sets" in metrics["analysis_summary"]
+
+
+def test_compute_hevy_metrics_summary_contains_volume():
+    metrics = compute_hevy_metrics(_make_exercises_json())
+    assert "kg total volume" in metrics["analysis_summary"]
+
+
+def test_compute_hevy_metrics_empty_json_returns_empty():
+    assert compute_hevy_metrics(None) == {}
+    assert compute_hevy_metrics("") == {}
+
+
+def test_compute_hevy_metrics_invalid_json_returns_empty():
+    assert compute_hevy_metrics("not-json") == {}
+
+
+def test_compute_hevy_metrics_no_rpe_gives_none_avg():
+    exercises = [
+        {
+            "title": "Deadlift",
+            "primary_muscle_group": "Hamstrings",
+            "sets": [{"type": "normal", "weight_kg": 150.0, "reps": 3, "rpe": None}],
+        }
+    ]
+    metrics = compute_hevy_metrics(json.dumps(exercises))
+    assert metrics["avg_rpe"] is None

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,7 @@ import Profile from "./pages/Profile";
 import Settings from "./pages/Settings";
 
 type Tab = "chat" | "activities" | "charts" | "calendar" | "profile" | "settings";
-export type Mode = "running" | "cycling" | "hybrid";
+export type Mode = "running" | "cycling" | "hybrid" | "lifting";
 
 export interface ThemeConfig {
   accentClass: string;
@@ -47,6 +47,15 @@ export const THEMES: Record<Mode, ThemeConfig> = {
     accentFocus: "focus:border-purple-500/40 focus:ring-purple-500/10",
     accentActive: "bg-purple-500/20 text-purple-400",
     label: "Hybrid Coach",
+  },
+  lifting: {
+    accentClass: "text-orange-400",
+    accentBg: "bg-orange-500/20",
+    accentBorder: "border-orange-500/30",
+    accentButton: "bg-orange-600 hover:bg-orange-500",
+    accentFocus: "focus:border-orange-500/40 focus:ring-orange-500/10",
+    accentActive: "bg-orange-500/20 text-orange-400",
+    label: "Lifting Coach",
   },
 };
 
@@ -97,6 +106,7 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 const VALID_TABS = new Set<string>([...TABS.map((t) => t.id), "settings"]);
+const HIDDEN_IN_LIFTING = new Set<Tab>(["charts", "calendar"]);
 
 function tabFromHash(): Tab {
   const hash = location.hash.slice(1);
@@ -144,6 +154,13 @@ export default function App() {
 
   const theme = THEMES[mode];
 
+  // Redirect away from tabs that aren't available in the current mode
+  useEffect(() => {
+    if (mode === "lifting" && HIDDEN_IN_LIFTING.has(tab)) {
+      navigate("chat");
+    }
+  }, [mode]);
+
   if (!modeLoaded) {
     return (
       <div className="flex h-screen bg-gray-950 items-center justify-center text-gray-500 text-sm">
@@ -152,7 +169,8 @@ export default function App() {
     );
   }
 
-  const allNavTabs: { id: Tab; label: string }[] = [...TABS, { id: "settings", label: "Settings" }];
+  const visibleTabs = TABS.filter((t) => mode !== "lifting" || !HIDDEN_IN_LIFTING.has(t.id));
+  const allNavTabs: { id: Tab; label: string }[] = [...visibleTabs, { id: "settings", label: "Settings" }];
   const mobileNavTabs = allNavTabs.filter((t) => t.id !== "calendar");
 
   return (
@@ -164,7 +182,7 @@ export default function App() {
           <p className="text-xs text-gray-500 mt-0.5">{theme.label}</p>
         </div>
         <ul className="flex-1 p-2 space-y-1">
-          {TABS.map((t) => (
+          {visibleTabs.map((t) => (
             <li key={t.id}>
               <button
                 onClick={() => navigate(t.id)}

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -36,6 +36,10 @@ interface Activity {
   deep_dive_completed_at: string | null;
   deep_dive_model: string | null;
   user_notes: string | null;
+  // Lifting fields
+  exercises_json?: string | null;
+  total_volume_kg?: number | null;
+  total_sets?: number | null;
 }
 
 interface Props {
@@ -43,7 +47,9 @@ interface Props {
   theme: ThemeConfig;
 }
 
-type SortKey = "date" | "name" | "distance_m" | "moving_time_s" | "avg_pace_s_per_km" | "avg_hr" | "elevation_gain_m";
+type SortKey =
+  | "date" | "name" | "distance_m" | "moving_time_s" | "avg_pace_s_per_km" | "avg_hr" | "elevation_gain_m"
+  | "total_volume_kg" | "total_sets";
 type SortDir = "asc" | "desc";
 
 function formatPace(s: number | null): string {
@@ -70,6 +76,15 @@ function formatPaceFade(s: number | null): string {
   if (s === null) return "—";
   const abs = Math.round(Math.abs(s));
   return s > 0 ? `+${abs}s/mi` : `−${abs}s/mi`;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatSet(s: any): string {
+  const weight = s.weight_kg != null ? `${s.weight_kg} kg` : "BW";
+  if (s.reps != null) return `${weight} × ${s.reps}`;
+  if (s.duration_seconds != null) return `${weight} × ${s.duration_seconds}s`;
+  if (s.distance_meters != null) return `${weight} × ${s.distance_meters}m`;
+  return weight;
 }
 
 function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
@@ -157,11 +172,74 @@ function HrZonesBar({ a }: { a: Activity }) {
   );
 }
 
+/** Exercise breakdown panel section for lifting workouts. */
+function ExerciseBreakdown({ exercises_json }: { exercises_json: string }) {
+  const [showAll, setShowAll] = useState(false);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let exercises: any[] = [];
+  try {
+    exercises = JSON.parse(exercises_json);
+  } catch {
+    return null;
+  }
+  if (exercises.length === 0) return null;
+
+  const visible = showAll ? exercises : exercises.slice(0, 3);
+  const hasMore = exercises.length > 3;
+
+  return (
+    <section className="space-y-3">
+      <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Exercises</h4>
+      <div className="space-y-4">
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+        {visible.map((ex: any, i: number) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const warmupSets = (ex.sets ?? []).filter((s: any) => s.type === "warmup");
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const workingSets = (ex.sets ?? []).filter((s: any) => s.type !== "warmup");
+          const muscleGroup = ex.muscle_group ?? ex.primary_muscle_group ?? "";
+          return (
+            <div key={i} className="border-l-2 border-gray-700 pl-3">
+              <div className="flex items-baseline justify-between gap-2 mb-1.5">
+                <span className="text-sm font-medium text-gray-200">{ex.title ?? ex.name ?? "Exercise"}</span>
+                {muscleGroup && (
+                  <span className="text-xs text-gray-500 shrink-0">{muscleGroup}</span>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-x-3 gap-y-1">
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                {warmupSets.map((s: any, j: number) => (
+                  <span key={`w${j}`} className="text-xs text-gray-600 italic">{formatSet(s)}</span>
+                ))}
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                {workingSets.map((s: any, j: number) => (
+                  <span key={j} className="text-xs text-gray-400">{formatSet(s)}</span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {hasMore && !showAll && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+        >
+          Show all {exercises.length} exercises
+        </button>
+      )}
+    </section>
+  );
+}
+
 export default function Activities({ mode, theme }: Props) {
   const [activities, setActivities] = useState<Activity[]>([]);
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
   const [syncMsg, setSyncMsg] = useState("");
+
+  const isLifting = mode === "lifting";
 
   // Sorting
   const [sortKey, setSortKey] = useState<SortKey>("date");
@@ -193,6 +271,12 @@ export default function Activities({ mode, theme }: Props) {
       .finally(() => setLoading(false));
   }, [mode]);
 
+  // Reset sort key when switching modes to avoid invalid keys
+  useEffect(() => {
+    setSortKey("date");
+    setSortDir("desc");
+  }, [mode]);
+
   function openPanel(id: number) {
     const act = activities.find((a) => a.id === id);
     setSelectedId(id);
@@ -218,13 +302,12 @@ export default function Activities({ mode, theme }: Props) {
     setSyncing(true);
     setSyncMsg("");
     try {
-      const res = await fetch("/api/sync", { method: "POST" });
+      const url = isLifting ? "/api/hevy/sync" : "/api/sync";
+      const res = await fetch(url, { method: "POST" });
       const data = await res.json();
-      setSyncMsg(
-        data.new_activities > 0
-          ? `${data.new_activities} new activit${data.new_activities === 1 ? "y" : "ies"} synced.`
-          : "Already up to date."
-      );
+      const count = data.new_activities ?? data.new_workouts ?? 0;
+      const noun = isLifting ? "session" : "activit";
+      setSyncMsg(count > 0 ? `${count} new ${noun}${isLifting ? (count === 1 ? "" : "s") : (count === 1 ? "y" : "ies")} synced.` : "Already up to date.");
       const rows = await fetch(`/api/activities?mode=${mode}`).then((r) => r.json());
       setActivities(rows);
     } catch {
@@ -304,16 +387,18 @@ export default function Activities({ mode, theme }: Props) {
     }
     if (dateFrom) rows = rows.filter((a) => a.date >= dateFrom);
     if (dateTo)   rows = rows.filter((a) => a.date <= dateTo);
-    if (minDist)  rows = rows.filter((a) => (a.distance_m ?? 0) / 1000 >= parseFloat(minDist));
+    if (!isLifting && minDist) rows = rows.filter((a) => (a.distance_m ?? 0) / 1000 >= parseFloat(minDist));
 
     return [...rows].sort((a, b) => {
-      const av = a[sortKey] ?? (sortKey === "name" ? "" : -Infinity);
-      const bv = b[sortKey] ?? (sortKey === "name" ? "" : -Infinity);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const av = (a as any)[sortKey] ?? (sortKey === "name" ? "" : -Infinity);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const bv = (b as any)[sortKey] ?? (sortKey === "name" ? "" : -Infinity);
       if (av < bv) return sortDir === "asc" ? -1 : 1;
       if (av > bv) return sortDir === "asc" ? 1 : -1;
       return 0;
     });
-  }, [activities, search, dateFrom, dateTo, minDist, sortKey, sortDir]);
+  }, [activities, search, dateFrom, dateTo, minDist, sortKey, sortDir, isLifting]);
 
   const paceLabel = mode === "cycling" ? "Speed" : mode === "hybrid" ? "Pace/Speed" : "Pace";
   const focusClass = "focus:outline-none focus:border-gray-500";
@@ -330,7 +415,7 @@ export default function Activities({ mode, theme }: Props) {
     );
   }
 
-  const filtersActive = search || dateFrom || dateTo || minDist;
+  const filtersActive = search || dateFrom || dateTo || (!isLifting && minDist);
 
   // ── Panel helpers ────────────────────────────────────────────────────────
 
@@ -363,12 +448,18 @@ export default function Activities({ mode, theme }: Props) {
     selectedActivity.hr_zone_1_pct !== null
   );
 
+  // Count distinct exercises from exercises_json
+  function exerciseCount(a: Activity): number {
+    if (!a.exercises_json) return 0;
+    try { return JSON.parse(a.exercises_json).length; } catch { return 0; }
+  }
+
   return (
     <div className="flex flex-col h-full p-6 gap-3">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-gray-100">
-          Activities{" "}
+          {isLifting ? "Sessions" : "Activities"}{" "}
           <span className="text-sm font-normal text-gray-400">
             ({filtered.length}{filtersActive ? ` of ${activities.length}` : ""})
           </span>
@@ -380,7 +471,7 @@ export default function Activities({ mode, theme }: Props) {
             disabled={syncing}
             className={`px-3 py-1.5 rounded-md ${theme.accentButton} text-white text-sm disabled:opacity-50 transition-colors`}
           >
-            {syncing ? "Syncing…" : "Sync Strava"}
+            {syncing ? "Syncing…" : isLifting ? "Sync HEVY" : "Sync Strava"}
           </button>
         </div>
       </div>
@@ -409,15 +500,17 @@ export default function Activities({ mode, theme }: Props) {
           title="To date"
           className={`rounded-md bg-gray-900 border border-gray-700 px-3 py-1.5 text-sm text-gray-100 ${focusClass}`}
         />
-        <input
-          type="number"
-          placeholder="Min km"
-          value={minDist}
-          onChange={(e) => setMinDist(e.target.value)}
-          min="0"
-          step="1"
-          className={`rounded-md bg-gray-900 border border-gray-700 px-3 py-1.5 text-sm text-gray-100 placeholder-gray-500 ${focusClass} w-24`}
-        />
+        {!isLifting && (
+          <input
+            type="number"
+            placeholder="Min km"
+            value={minDist}
+            onChange={(e) => setMinDist(e.target.value)}
+            min="0"
+            step="1"
+            className={`rounded-md bg-gray-900 border border-gray-700 px-3 py-1.5 text-sm text-gray-100 placeholder-gray-500 ${focusClass} w-24`}
+          />
+        )}
         {filtersActive && (
           <button
             onClick={() => { setSearch(""); setDateFrom(""); setDateTo(""); setMinDist(""); }}
@@ -436,21 +529,35 @@ export default function Activities({ mode, theme }: Props) {
           <table className="w-full text-sm">
             <thead>
               <tr className="bg-gray-900 text-gray-400 text-left sticky top-0">
-                <Th label="Date"      col="date" />
-                <Th label="Name"      col="name" />
-                <Th label="Dist (km)" col="distance_m"       right />
-                <Th label="Time"      col="moving_time_s"     right />
-                <Th label={paceLabel} col="avg_pace_s_per_km" right />
-                <Th label="Avg HR"    col="avg_hr"            right />
-                <Th label="Elev (m)"  col="elevation_gain_m"  right />
-                <th className="px-4 py-2 font-medium whitespace-nowrap text-right"></th>
+                {isLifting ? (
+                  <>
+                    <Th label="Date"        col="date" />
+                    <Th label="Name"        col="name" />
+                    <Th label="Volume (kg)" col="total_volume_kg"  right />
+                    <Th label="Time"        col="moving_time_s"    right />
+                    <Th label="Sets"        col="total_sets"       right />
+                    <th className="px-4 py-2 font-medium whitespace-nowrap text-right text-gray-400">Exercises</th>
+                    <th className="px-4 py-2 font-medium whitespace-nowrap text-right"></th>
+                  </>
+                ) : (
+                  <>
+                    <Th label="Date"      col="date" />
+                    <Th label="Name"      col="name" />
+                    <Th label="Dist (km)" col="distance_m"       right />
+                    <Th label="Time"      col="moving_time_s"     right />
+                    <Th label={paceLabel} col="avg_pace_s_per_km" right />
+                    <Th label="Avg HR"    col="avg_hr"            right />
+                    <Th label="Elev (m)"  col="elevation_gain_m"  right />
+                    <th className="px-4 py-2 font-medium whitespace-nowrap text-right"></th>
+                  </>
+                )}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-800">
               {filtered.length === 0 ? (
                 <tr>
                   <td colSpan={8} className="px-4 py-8 text-center text-gray-500">
-                    No activities match your filters.
+                    No {isLifting ? "sessions" : "activities"} match your filters.
                   </td>
                 </tr>
               ) : (
@@ -466,34 +573,53 @@ export default function Activities({ mode, theme }: Props) {
                       {a.analysis_summary && (
                         <p className="text-xs text-gray-500 mt-0.5 max-w-xs truncate">{a.analysis_summary}</p>
                       )}
-                      {(a.cardiac_decoupling_pct !== null || a.effort_efficiency_score !== null) && (
+                      {!isLifting && (a.cardiac_decoupling_pct !== null || a.effort_efficiency_score !== null) && (
                         <div className="flex gap-1 mt-1 flex-wrap">
                           <DecouplingBadge val={a.cardiac_decoupling_pct} />
                           <EfficiencyBadge val={a.effort_efficiency_score} />
                         </div>
                       )}
                     </td>
-                    <td className="px-4 py-2 text-right text-gray-100">
-                      {((a.distance_m || 0) / 1000).toFixed(2)}
-                    </td>
-                    <td className="px-4 py-2 text-right text-gray-400">
-                      {formatDuration(a.moving_time_s)}
-                    </td>
-                    <td className="px-4 py-2 text-right text-gray-400">
-                      {mode === "cycling"
-                        ? formatSpeed(a.avg_pace_s_per_km)
-                        : mode === "hybrid"
-                        ? (a.sport_type === "Ride" || a.sport_type === "VirtualRide" || a.sport_type === "GravelRide"
+                    {isLifting ? (
+                      <>
+                        <td className="px-4 py-2 text-right text-gray-100">
+                          {a.total_volume_kg != null ? a.total_volume_kg.toFixed(0) : "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-400">
+                          {formatDuration(a.moving_time_s)}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-400">
+                          {a.total_sets ?? "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-400">
+                          {exerciseCount(a) || "—"}
+                        </td>
+                      </>
+                    ) : (
+                      <>
+                        <td className="px-4 py-2 text-right text-gray-100">
+                          {((a.distance_m || 0) / 1000).toFixed(2)}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-400">
+                          {formatDuration(a.moving_time_s)}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-400">
+                          {mode === "cycling"
                             ? formatSpeed(a.avg_pace_s_per_km)
-                            : formatPace(a.avg_pace_s_per_km))
-                        : formatPace(a.avg_pace_s_per_km)}
-                    </td>
-                    <td className="px-4 py-2 text-right text-gray-400">
-                      {a.avg_hr ?? "—"}
-                    </td>
-                    <td className="px-4 py-2 text-right text-gray-400">
-                      {a.elevation_gain_m != null ? Math.round(a.elevation_gain_m) : "—"}
-                    </td>
+                            : mode === "hybrid"
+                            ? (a.sport_type === "Ride" || a.sport_type === "VirtualRide" || a.sport_type === "GravelRide"
+                                ? formatSpeed(a.avg_pace_s_per_km)
+                                : formatPace(a.avg_pace_s_per_km))
+                            : formatPace(a.avg_pace_s_per_km)}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-400">
+                          {a.avg_hr ?? "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-400">
+                          {a.elevation_gain_m != null ? Math.round(a.elevation_gain_m) : "—"}
+                        </td>
+                      </>
+                    )}
                     <td className="px-4 py-2 text-right" onClick={(e) => e.stopPropagation()}>
                       <button
                         onClick={() => openPanel(a.id)}
@@ -527,15 +653,17 @@ export default function Activities({ mode, theme }: Props) {
               <div className="min-w-0">
                 <div className="flex items-center gap-2 flex-wrap">
                   <h3 className="text-gray-100 font-semibold truncate">{selectedActivity.name || "Activity"}</h3>
-                  <a
-                    href={`https://www.strava.com/activities/${selectedActivity.id}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="text-xs text-orange-500 hover:text-orange-400 transition-colors shrink-0"
-                  >
-                    Strava ↗
-                  </a>
+                  {!isLifting && (
+                    <a
+                      href={`https://www.strava.com/activities/${selectedActivity.id}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="text-xs text-orange-500 hover:text-orange-400 transition-colors shrink-0"
+                    >
+                      Strava ↗
+                    </a>
+                  )}
                 </div>
                 <p className="text-xs text-gray-500 mt-0.5">
                   {selectedActivity.date}
@@ -554,24 +682,50 @@ export default function Activities({ mode, theme }: Props) {
             <div className="overflow-y-auto flex-1 p-5 space-y-6">
 
               {/* Basic stats row */}
-              <div className="grid grid-cols-4 gap-2">
-                <MetricTile
-                  label="Distance"
-                  value={`${((selectedActivity.distance_m || 0) / 1000).toFixed(2)} km`}
-                />
-                <MetricTile
-                  label="Time"
-                  value={formatDuration(selectedActivity.moving_time_s)}
-                />
-                <MetricTile
-                  label={mode === "cycling" ? "Speed" : "Pace"}
-                  value={paceLabel2(selectedActivity)}
-                />
-                <MetricTile
-                  label="Avg HR"
-                  value={selectedActivity.avg_hr ? `${Math.round(selectedActivity.avg_hr)} bpm` : "—"}
-                />
-              </div>
+              {isLifting ? (
+                <div className="grid grid-cols-4 gap-2">
+                  <MetricTile
+                    label="Volume (kg)"
+                    value={selectedActivity.total_volume_kg != null ? selectedActivity.total_volume_kg.toFixed(0) : "—"}
+                  />
+                  <MetricTile
+                    label="Time"
+                    value={formatDuration(selectedActivity.moving_time_s)}
+                  />
+                  <MetricTile
+                    label="Sets"
+                    value={selectedActivity.total_sets != null ? String(selectedActivity.total_sets) : "—"}
+                  />
+                  <MetricTile
+                    label="Exercises"
+                    value={String(exerciseCount(selectedActivity) || "—")}
+                  />
+                </div>
+              ) : (
+                <div className="grid grid-cols-4 gap-2">
+                  <MetricTile
+                    label="Distance"
+                    value={`${((selectedActivity.distance_m || 0) / 1000).toFixed(2)} km`}
+                  />
+                  <MetricTile
+                    label="Time"
+                    value={formatDuration(selectedActivity.moving_time_s)}
+                  />
+                  <MetricTile
+                    label={mode === "cycling" ? "Speed" : "Pace"}
+                    value={paceLabel2(selectedActivity)}
+                  />
+                  <MetricTile
+                    label="Avg HR"
+                    value={selectedActivity.avg_hr ? `${Math.round(selectedActivity.avg_hr)} bpm` : "—"}
+                  />
+                </div>
+              )}
+
+              {/* Exercise breakdown — lifting only */}
+              {isLifting && selectedActivity.exercises_json && (
+                <ExerciseBreakdown exercises_json={selectedActivity.exercises_json} />
+              )}
 
               {/* Analysis summary */}
               {selectedActivity.analysis_summary && (
@@ -581,8 +735,8 @@ export default function Activities({ mode, theme }: Props) {
                 </div>
               )}
 
-              {/* Metrics grid */}
-              {hasMetrics && (
+              {/* Cardio metrics grid — running/cycling only */}
+              {!isLifting && hasMetrics && (
                 <section className="space-y-3">
                   <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Computed Metrics</h4>
 
@@ -640,8 +794,8 @@ export default function Activities({ mode, theme }: Props) {
                 </section>
               )}
 
-              {/* No analysis yet */}
-              {!hasMetrics && selectedActivity.analysis_status !== "done" && (
+              {/* No analysis yet — running/cycling only */}
+              {!isLifting && !hasMetrics && selectedActivity.analysis_status !== "done" && (
                 <p className="text-sm text-gray-600">
                   {selectedActivity.analysis_status === "skipped"
                     ? "No stream data available for this activity."

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -78,6 +78,10 @@ const MessageList = memo(function MessageList({
       heading: "How can I help with your training?",
       sub: "Ask about your running and cycling, cross-training load, or anything else.",
     },
+    lifting: {
+      heading: "How can I help with your lifting?",
+      sub: "Ask about your recent sessions, volume, strength progress, or programming.",
+    },
   }[mode];
 
   return (

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -54,6 +54,14 @@ const MODE_CARDS: {
     borderSelected: "border-purple-500",
     dotClass: "bg-purple-500",
   },
+  {
+    id: "lifting",
+    label: "Lifting",
+    description: "Weightlifting sessions from HEVY. Coaching focused on volume, strength, and progressive overload.",
+    accentClass: "text-orange-400",
+    borderSelected: "border-orange-500",
+    dotClass: "bg-orange-500",
+  },
 ];
 
 type SyncState = "idle" | "syncing" | "done" | "error";
@@ -61,6 +69,8 @@ type SyncState = "idle" | "syncing" | "done" | "error";
 export default function Settings({ mode, setMode, theme, onProviderChanged }: Props) {
   const [syncState, setSyncState] = useState<SyncState>("idle");
   const [syncCount, setSyncCount] = useState<number | null>(null);
+  const [hevySyncState, setHevySyncState] = useState<SyncState>("idle");
+  const [hevySyncCount, setHevySyncCount] = useState<number | null>(null);
   const [providers, setProviders] = useState<Provider[]>([]);
   const [switchingProvider, setSwitchingProvider] = useState(false);
   const [providerModels, setProviderModels] = useState<Record<string, ProviderModel[]>>({});
@@ -128,6 +138,20 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
       );
     } finally {
       setChangingModel(false);
+    }
+  }
+
+  async function handleHevySync(full: boolean) {
+    setHevySyncState("syncing");
+    setHevySyncCount(null);
+    try {
+      const res = await fetch(`/api/hevy/sync${full ? "?full=true" : ""}`, { method: "POST" });
+      if (!res.ok) throw new Error();
+      const { new_workouts } = await res.json();
+      setHevySyncCount(new_workouts);
+      setHevySyncState("done");
+    } catch {
+      setHevySyncState("error");
     }
   }
 
@@ -277,6 +301,45 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
               )}
               {syncState === "error" && (
                 <span className="text-xs text-red-400">Sync failed. Check your Strava credentials.</span>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+              HEVY Sync
+            </h3>
+            <p className="text-xs text-gray-600 mb-3">
+              Fetches your weightlifting sessions from HEVY. Requires a{" "}
+              <span className="text-gray-400">Hevy Pro</span> subscription and{" "}
+              <code className="text-gray-500">HEVY_API_KEY</code> in{" "}
+              <code className="text-gray-500">.env</code> (get your key at{" "}
+              <span className="text-gray-400">hevy.com/settings?developer</span>).
+            </p>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => handleHevySync(false)}
+                disabled={hevySyncState === "syncing"}
+                className="px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-orange-600 hover:bg-orange-500 text-white"
+              >
+                {hevySyncState === "syncing" ? "Syncing…" : "Sync New"}
+              </button>
+              <button
+                onClick={() => handleHevySync(true)}
+                disabled={hevySyncState === "syncing"}
+                className="px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-gray-700 hover:bg-gray-600 text-white"
+              >
+                Full Sync
+              </button>
+              {hevySyncState === "done" && (
+                <span className="text-xs text-gray-400">
+                  {hevySyncCount === 0
+                    ? "Already up to date."
+                    : `${hevySyncCount} new session${hevySyncCount === 1 ? "" : "s"} synced.`}
+                </span>
+              )}
+              {hevySyncState === "error" && (
+                <span className="text-xs text-red-400">Sync failed. Check your HEVY_API_KEY.</span>
               )}
             </div>
           </section>


### PR DESCRIPTION
## Summary
- **New lifting mode**: orange-accented fourth coaching mode; Charts/Calendar tabs hidden (not applicable to lifting)
- **HEVY API sync**: incremental sync via `/v1/workouts/events`, falls back to full paginated sync on first run; `POST /api/hevy/sync` endpoint with optional `?full=true`
- **DB migration 005**: adds `hevy_workout_id`, `exercises_json`, `total_volume_kg`, `total_sets` columns to activities table
- **Lifting analysis**: `hevy_analysis.py` computes volume, sets, avg RPE, estimated 1RMs (Epley formula), muscle group breakdown, and rule-based NL summary at sync time
- **Lifting system prompt**: separate coaching identity, training log format (Date | Name | Duration | Sets | Volume | RPE), and athlete profile defaults for lifting background/bests/equipment
- **Activities page redesign**: lifting mode shows Volume/Sets/Exercises columns; slide-out panel has per-exercise breakdown with warmup vs working sets (weight × reps), no cardio metrics (HR zones, pace fade, cardiac decoupling, etc.)
- **Deep dive for lifting**: bypasses Strava streams entirely — formats exercises from `exercises_json` and uses `LIFTING_DEEP_DIVE_SYSTEM_PROMPT` covering volume, set quality, 1RM trends, fatigue signs
- **Settings page**: HEVY sync section with "Sync New" and "Full Sync" buttons
- **`STRIDES_DATA_DIR` env var**: override the data directory for running multiple isolated instances

## Test plan
- [x] `make test` — 291 tests should pass
- [ ] Switch to lifting mode → Activities shows "Sessions" heading, Volume/Sets/Exercises columns
- [x] Sync HEVY → workouts appear in activities list
- [x] Open a session → exercise breakdown shows with warmup sets in muted italic, working sets normal; Volume/Sets/Exercises tiles in header
- [x] Run Deep Dive on a lifting session → works without Strava, produces strength-focused report
- [x] Strava link absent from lifting session panel
- [x] Switch back to running → page looks exactly as before, all cardio metrics present
- [x] Sort by Volume / Sets works in lifting mode
- [x] Min distance filter hidden in lifting mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)