### PR TITLE
refactor(modes): centralize mode config into a single ModeConfig registry

### DIFF
--- a/strides_ai/api/app.py
+++ b/strides_ai/api/app.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .. import db
 from ..config import UPLOADS_DIR, get_settings
+from ..modes import MODES
 from .deps import init_backend
 from .routers import (
     activities,
@@ -57,3 +58,16 @@ app.include_router(history.router, prefix="/api")
 app.include_router(analysis.router, prefix="/api")
 app.include_router(calendar.router, prefix="/api")
 app.include_router(status.router, prefix="/api")
+
+
+@app.get("/api/modes")
+def get_modes():
+    """Return metadata for all coaching modes (used by frontend for tab visibility etc.)."""
+    return {
+        name: {
+            "activity_label": cfg.activity_label,
+            "hidden_tabs": sorted(cfg.hidden_tabs),
+            "has_analysis": cfg.has_analysis,
+        }
+        for name, cfg in MODES.items()
+    }

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -3,114 +3,13 @@
 import sqlite3
 from datetime import datetime
 
-from .db import RUN_TYPES, LIFT_TYPES
 from . import db
+from .modes import MODES
 
 RECALL_MESSAGES = 40
 # Number of most-recent activities always pinned in the system prompt each turn.
 # The full training log is seeded once in conversation history via build_initial_history.
 RECENT_ACTIVITIES_IN_SYSTEM = 30
-
-RUNNING_SYSTEM_PROMPT = """\
-You are an experienced, data-driven running coach with access to the athlete's \
-complete Strava training log. Your role is to:
-
-- Analyse training load, trends, and patterns from the data provided.
-- Answer questions about specific workouts, weekly/monthly volume, and progress.
-- Give evidence-based coaching advice: pacing, recovery, race preparation, \
-injury prevention, and periodisation.
-- Be concise but thorough. When referencing specific runs, cite the date and \
-key metrics (distance, pace, HR).
-- Use metric units (km, min/km) unless the athlete asks otherwise.
-- When advising on nutrition for a run, suggest a concrete sample loadout \
-(e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
-preferred snacks in their profile, choose from those; otherwise use sensible \
-defaults based on run distance and intensity.
-
-The athlete's complete training log is included below. Treat it as ground \
-truth for all data-related questions.
-
-**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
-goals, upcoming races, injuries, preferences, or any key context that should \
-persist across sessions.\
-"""
-
-CYCLING_SYSTEM_PROMPT = """\
-You are an experienced, data-driven cycling coach with access to the athlete's \
-complete Strava training log. Your role is to:
-
-- Analyse training load, trends, and patterns from cycling data provided.
-- Answer questions about specific rides, weekly/monthly volume, and progress.
-- Give evidence-based coaching advice: pacing, power, recovery, race preparation, \
-injury prevention, and periodisation for cyclists.
-- Be concise but thorough. When referencing specific rides, cite the date and \
-key metrics (distance, speed, HR).
-- Use metric units (km, km/h) unless the athlete asks otherwise.
-- When advising on nutrition for a ride, suggest a concrete sample loadout \
-(e.g. "2 gels, 1 energy bar, 750 ml electrolytes"). If the athlete has listed \
-preferred snacks in their profile, choose from those; otherwise use sensible \
-defaults based on ride duration and intensity.
-
-The athlete's complete training log is included below. Treat it as ground \
-truth for all data-related questions.
-
-**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
-goals, upcoming events, injuries, preferences, or any key context that should \
-persist across sessions.\
-"""
-
-HYBRID_SYSTEM_PROMPT = """\
-You are an experienced, data-driven multisport coach with access to the athlete's \
-complete Strava training log covering both running and cycling. Your role is to:
-
-- Analyse training load, trends, and patterns across all sport types.
-- Answer questions about specific workouts, weekly/monthly volume, and progress.
-- Give evidence-based coaching advice covering both running and cycling: \
-pacing, recovery, race preparation, injury prevention, and periodisation.
-- Be concise but thorough. When referencing specific activities, cite the date, \
-sport type, and key metrics.
-- Use metric units unless the athlete asks otherwise.
-- When advising on nutrition for any activity, suggest a concrete sample loadout \
-(e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
-preferred snacks in their profile, choose from those; otherwise use sensible \
-defaults based on activity duration and intensity.
-
-The athlete's complete training log is included below. Treat it as ground \
-truth for all data-related questions.
-
-**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
-goals, upcoming events, injuries, preferences, or any key context that should \
-persist across sessions.\
-"""
-
-LIFTING_SYSTEM_PROMPT = """\
-You are an experienced, data-driven strength and conditioning coach with access to the athlete's \
-complete HEVY training log. Your role is to:
-
-- Analyse training volume, intensity, and progression from the data provided.
-- Answer questions about specific sessions, weekly volume, and strength progress.
-- Give evidence-based coaching advice: programming, progressive overload, recovery, \
-injury prevention, deload timing, and exercise selection.
-- Be concise but thorough. When referencing specific sessions, cite the date and \
-key metrics (exercises, volume, RPE, estimated 1RM).
-- Use metric units (kg) unless the athlete asks otherwise.
-- When estimating 1-rep maxes, use the Epley formula (weight × (1 + reps/30)) and \
-note it is an estimate.
-
-The athlete's complete training log is included below. Treat it as ground \
-truth for all data-related questions.
-
-**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
-goals, upcoming competitions, injuries, preferences, or any key context that should \
-persist across sessions.\
-"""
-
-_PROMPT_BY_MODE = {
-    "running": RUNNING_SYSTEM_PROMPT,
-    "cycling": CYCLING_SYSTEM_PROMPT,
-    "hybrid": HYBRID_SYSTEM_PROMPT,
-    "lifting": LIFTING_SYSTEM_PROMPT,
-}
 
 
 def build_system(
@@ -119,7 +18,8 @@ def build_system(
     mode: str = "running",
     activities: list | None = None,
 ) -> str:
-    prompt = _PROMPT_BY_MODE.get(mode, RUNNING_SYSTEM_PROMPT)
+    cfg = MODES.get(mode, MODES["running"])
+    prompt = cfg.system_prompt
 
     now = datetime.now().astimezone()
     day_str = now.strftime("%A, %B %-d, %Y")
@@ -163,9 +63,7 @@ def build_system(
     # The full training log is seeded once in conversation history.
     recent = (activities or [])[:RECENT_ACTIVITIES_IN_SYSTEM]
 
-    # Inject cardio metrics guide when any activity has been analyzed (not relevant for lifting)
-    has_analysis = mode != "lifting" and any(a.get("analysis_summary") for a in recent)
-    if has_analysis:
+    if cfg.has_analysis and any(a.get("analysis_summary") for a in recent):
         prompt += (
             "\n\n## Analysis Metrics Guide\n"
             "The ANALYSIS column in the training log contains auto-generated summaries. "
@@ -188,130 +86,16 @@ def build_system(
     return prompt
 
 
-def _format_pace(s_per_km: float | None) -> str:
-    if s_per_km is None:
-        return "—"
-    mins = int(s_per_km // 60)
-    secs = int(s_per_km % 60)
-    return f"{mins}:{secs:02d}/km"
-
-
-def _format_speed(s_per_km: float | None) -> str:
-    if s_per_km is None or s_per_km <= 0:
-        return "—"
-    kph = 3600 / s_per_km
-    return f"{kph:.1f}km/h"
-
-
-def _format_duration(seconds: int | None) -> str:
-    if seconds is None:
-        return "—"
-    h, rem = divmod(seconds, 3600)
-    m, s = divmod(rem, 60)
-    if h:
-        return f"{h}h{m:02d}m{s:02d}s"
-    return f"{m}m{s:02d}s"
-
-
 def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
     if not rows:
         return "No activities found."
-
-    if mode == "lifting":
-        header = "DATE       | NAME                           | DURATION | SETS | VOLUME(kg) | RPE | ANALYSIS"
-        sep = "-" * 140
-        lines = [header, sep]
-        for r in reversed(rows):
-            analysis = (r.get("analysis_summary") or "")[:60]
-            lines.append(
-                f"{r['date'] or '?':10s} | "
-                f"{(r['name'] or '')[:30]:30s} | "
-                f"{_format_duration(r['moving_time_s']):8s} | "
-                f"{r['total_sets'] or '—':4} | "
-                f"{r['total_volume_kg'] or '—':10} | "
-                f"{r['perceived_exertion'] or '—':3} | "
-                f"{analysis}"
-            )
-        total_volume = sum((r["total_volume_kg"] or 0) for r in rows)
-        lines.append(sep)
-        lines.append(f"Total: {len(rows)} sessions, {total_volume:.0f} kg cumulative volume")
-        return "\n".join(lines)
-
-    if mode == "hybrid":
-        header = "DATE       | TYPE       | NAME                           | DIST(km) | DURATION | PACE/SPEED  | AVG HR | MAX HR | CADENCE | ELEV(m) | SUFFER | RPE | ANALYSIS"
-        sep = "-" * 215
-    elif mode == "cycling":
-        header = "DATE       | NAME                           | DIST(km) | DURATION | SPEED    | AVG HR | MAX HR | CADENCE(rpm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
-        sep = "-" * 200
-    else:
-        header = "DATE       | NAME                           | DIST(km) | DURATION | PACE     | AVG HR | MAX HR | CADENCE(spm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
-        sep = "-" * 200
-
-    lines = [header, sep]
-
+    cfg = MODES.get(mode, MODES["running"])
+    sep = "-" * cfg.log_sep_len
+    lines = [cfg.log_header, sep]
     for r in reversed(rows):
-        dist_km = (r["distance_m"] or 0) / 1000
-        sport = r["sport_type"] or ""
-        is_run = sport in RUN_TYPES
-
-        analysis = (r.get("analysis_summary") or "")[:60]
-
-        if mode == "hybrid":
-            pace_speed = (
-                _format_pace(r["avg_pace_s_per_km"])
-                if is_run
-                else _format_speed(r["avg_pace_s_per_km"])
-            )
-            lines.append(
-                f"{r['date'] or '?':10s} | "
-                f"{sport[:10]:10s} | "
-                f"{(r['name'] or '')[:30]:30s} | "
-                f"{dist_km:8.2f} | "
-                f"{_format_duration(r['moving_time_s']):8s} | "
-                f"{pace_speed:11s} | "
-                f"{r['avg_hr'] or '—':6} | "
-                f"{r['max_hr'] or '—':6} | "
-                f"{r['avg_cadence'] or '—':7} | "
-                f"{r['elevation_gain_m'] or '—':7} | "
-                f"{r['suffer_score'] or '—':6} | "
-                f"{r['perceived_exertion'] or '—':3} | "
-                f"{analysis}"
-            )
-        elif mode == "cycling":
-            lines.append(
-                f"{r['date'] or '?':10s} | "
-                f"{(r['name'] or '')[:30]:30s} | "
-                f"{dist_km:8.2f} | "
-                f"{_format_duration(r['moving_time_s']):8s} | "
-                f"{_format_speed(r['avg_pace_s_per_km']):8s} | "
-                f"{r['avg_hr'] or '—':6} | "
-                f"{r['max_hr'] or '—':6} | "
-                f"{r['avg_cadence'] or '—':12} | "
-                f"{r['elevation_gain_m'] or '—':7} | "
-                f"{r['suffer_score'] or '—':6} | "
-                f"{r['perceived_exertion'] or '—':3} | "
-                f"{analysis}"
-            )
-        else:  # running
-            lines.append(
-                f"{r['date'] or '?':10s} | "
-                f"{(r['name'] or '')[:30]:30s} | "
-                f"{dist_km:8.2f} | "
-                f"{_format_duration(r['moving_time_s']):8s} | "
-                f"{_format_pace(r['avg_pace_s_per_km']):8s} | "
-                f"{r['avg_hr'] or '—':6} | "
-                f"{r['max_hr'] or '—':6} | "
-                f"{r['avg_cadence'] or '—':12} | "
-                f"{r['elevation_gain_m'] or '—':7} | "
-                f"{r['suffer_score'] or '—':6} | "
-                f"{r['perceived_exertion'] or '—':3} | "
-                f"{analysis}"
-            )
-
-    total_km = sum((r["distance_m"] or 0) / 1000 for r in rows)
-    act_label = "runs" if mode == "running" else "rides" if mode == "cycling" else "activities"
+        lines.append(cfg.format_log_row(r))
     lines.append(sep)
-    lines.append(f"Total: {len(rows)} {act_label}, {total_km:.1f} km")
+    lines.append(cfg.format_log_total(rows))
     return "\n".join(lines)
 
 
@@ -327,19 +111,15 @@ def build_initial_history(
     history lives. It may be gracefully truncated by small-context models, but
     only the oldest runs are dropped — recent ones are protected by the system prompt.
     """
+    cfg = MODES.get(mode, MODES["running"])
     training_log = build_training_log(activities, mode)
-    act_label = (
-        "runs"
-        if mode == "running"
-        else "rides" if mode == "cycling" else "sessions" if mode == "lifting" else "activities"
-    )
     log_message = f"Here is the athlete's complete training log:\n\n```\n{training_log}\n```"
     return [
         {"role": "user", "content": log_message},
         {
             "role": "assistant",
             "content": (
-                f"Got it — I have your full training log loaded ({len(activities)} {act_label}). "
+                f"Got it — I have your full training log loaded ({len(activities)} {cfg.activity_label}). "
                 "What would you like to discuss?"
             ),
         },

--- a/strides_ai/db/activities.py
+++ b/strides_ai/db/activities.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlmodel import Session, select
 
 from .models import Activity, RUN_TYPES, CYCLE_TYPES, LIFT_TYPES
+from ..modes import MODES
 
 
 def get_latest_activity_date(session: Session) -> str | None:
@@ -102,26 +103,10 @@ def get_all(session: Session) -> list[Activity]:
 
 def get_for_mode(session: Session, mode: str) -> list[Activity]:
     """Return activities filtered to the active mode, newest-first."""
-    if mode == "running":
-        stmt = (
-            select(Activity)
-            .where(Activity.sport_type.in_(RUN_TYPES))
-            .order_by(Activity.date.desc())
-        )
-    elif mode == "cycling":
-        stmt = (
-            select(Activity)
-            .where(Activity.sport_type.in_(CYCLE_TYPES))
-            .order_by(Activity.date.desc())
-        )
-    elif mode == "lifting":
-        stmt = (
-            select(Activity)
-            .where(Activity.sport_type.in_(LIFT_TYPES))
-            .order_by(Activity.date.desc())
-        )
-    else:  # hybrid
-        stmt = select(Activity).order_by(Activity.date.desc())
+    cfg = MODES.get(mode, MODES["running"])
+    stmt = select(Activity).order_by(Activity.date.desc())
+    if cfg.sport_types is not None:
+        stmt = stmt.where(Activity.sport_type.in_(cfg.sport_types))
     return session.exec(stmt).all()
 
 

--- a/strides_ai/modes.py
+++ b/strides_ai/modes.py
@@ -1,0 +1,357 @@
+"""Central registry of coaching mode configuration.
+
+Each ModeConfig instance captures everything mode-specific:
+  - Which sport types to filter activities by
+  - The LLM system prompt
+  - Training log formatting (header, row, totals)
+  - Which profile sections to render
+  - UI metadata (hidden tabs, activity label)
+
+Adding a new mode means adding one ModeConfig entry to MODES.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from .db.models import CYCLE_TYPES, LIFT_TYPES, RUN_TYPES
+
+# ── System prompts ─────────────────────────────────────────────────────────────
+
+RUNNING_SYSTEM_PROMPT = """\
+You are an experienced, data-driven running coach with access to the athlete's \
+complete Strava training log. Your role is to:
+
+- Analyse training load, trends, and patterns from the data provided.
+- Answer questions about specific workouts, weekly/monthly volume, and progress.
+- Give evidence-based coaching advice: pacing, recovery, race preparation, \
+injury prevention, and periodisation.
+- Be concise but thorough. When referencing specific runs, cite the date and \
+key metrics (distance, pace, HR).
+- Use metric units (km, min/km) unless the athlete asks otherwise.
+- When advising on nutrition for a run, suggest a concrete sample loadout \
+(e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
+preferred snacks in their profile, choose from those; otherwise use sensible \
+defaults based on run distance and intensity.
+
+The athlete's complete training log is included below. Treat it as ground \
+truth for all data-related questions.
+
+**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
+goals, upcoming races, injuries, preferences, or any key context that should \
+persist across sessions.\
+"""
+
+CYCLING_SYSTEM_PROMPT = """\
+You are an experienced, data-driven cycling coach with access to the athlete's \
+complete Strava training log. Your role is to:
+
+- Analyse training load, trends, and patterns from cycling data provided.
+- Answer questions about specific rides, weekly/monthly volume, and progress.
+- Give evidence-based coaching advice: pacing, power, recovery, race preparation, \
+injury prevention, and periodisation for cyclists.
+- Be concise but thorough. When referencing specific rides, cite the date and \
+key metrics (distance, speed, HR).
+- Use metric units (km, km/h) unless the athlete asks otherwise.
+- When advising on nutrition for a ride, suggest a concrete sample loadout \
+(e.g. "2 gels, 1 energy bar, 750 ml electrolytes"). If the athlete has listed \
+preferred snacks in their profile, choose from those; otherwise use sensible \
+defaults based on ride duration and intensity.
+
+The athlete's complete training log is included below. Treat it as ground \
+truth for all data-related questions.
+
+**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
+goals, upcoming events, injuries, preferences, or any key context that should \
+persist across sessions.\
+"""
+
+HYBRID_SYSTEM_PROMPT = """\
+You are an experienced, data-driven multisport coach with access to the athlete's \
+complete Strava training log covering both running and cycling. Your role is to:
+
+- Analyse training load, trends, and patterns across all sport types.
+- Answer questions about specific workouts, weekly/monthly volume, and progress.
+- Give evidence-based coaching advice covering both running and cycling: \
+pacing, recovery, race preparation, injury prevention, and periodisation.
+- Be concise but thorough. When referencing specific activities, cite the date, \
+sport type, and key metrics.
+- Use metric units unless the athlete asks otherwise.
+- When advising on nutrition for any activity, suggest a concrete sample loadout \
+(e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
+preferred snacks in their profile, choose from those; otherwise use sensible \
+defaults based on activity duration and intensity.
+
+The athlete's complete training log is included below. Treat it as ground \
+truth for all data-related questions.
+
+**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
+goals, upcoming events, injuries, preferences, or any key context that should \
+persist across sessions.\
+"""
+
+LIFTING_SYSTEM_PROMPT = """\
+You are an experienced, data-driven strength and conditioning coach with access to the athlete's \
+complete HEVY training log. Your role is to:
+
+- Analyse training volume, intensity, and progression from the data provided.
+- Answer questions about specific sessions, weekly volume, and strength progress.
+- Give evidence-based coaching advice: programming, progressive overload, recovery, \
+injury prevention, deload timing, and exercise selection.
+- Be concise but thorough. When referencing specific sessions, cite the date and \
+key metrics (exercises, volume, RPE, estimated 1RM).
+- Use metric units (kg) unless the athlete asks otherwise.
+- When estimating 1-rep maxes, use the Epley formula (weight × (1 + reps/30)) and \
+note it is an estimate.
+
+The athlete's complete training log is included below. Treat it as ground \
+truth for all data-related questions.
+
+**Memory:** Use the save_memory tool proactively whenever the athlete mentions \
+goals, upcoming competitions, injuries, preferences, or any key context that should \
+persist across sessions.\
+"""
+
+
+# ── Training log format helpers ────────────────────────────────────────────────
+
+
+def _format_pace(s_per_km: float | None) -> str:
+    if s_per_km is None:
+        return "—"
+    mins = int(s_per_km // 60)
+    secs = int(s_per_km % 60)
+    return f"{mins}:{secs:02d}/km"
+
+
+def _format_speed(s_per_km: float | None) -> str:
+    if s_per_km is None or s_per_km <= 0:
+        return "—"
+    kph = 3600 / s_per_km
+    return f"{kph:.1f}km/h"
+
+
+def _format_duration(seconds: int | None) -> str:
+    if seconds is None:
+        return "—"
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h{m:02d}m{s:02d}s"
+    return f"{m}m{s:02d}s"
+
+
+# ── Per-mode log row formatters ────────────────────────────────────────────────
+
+
+def _running_log_row(r: dict) -> str:
+    dist_km = (r["distance_m"] or 0) / 1000
+    analysis = (r.get("analysis_summary") or "")[:60]
+    return (
+        f"{r['date'] or '?':10s} | "
+        f"{(r['name'] or '')[:30]:30s} | "
+        f"{dist_km:8.2f} | "
+        f"{_format_duration(r['moving_time_s']):8s} | "
+        f"{_format_pace(r['avg_pace_s_per_km']):8s} | "
+        f"{r['avg_hr'] or '—':6} | "
+        f"{r['max_hr'] or '—':6} | "
+        f"{r['avg_cadence'] or '—':12} | "
+        f"{r['elevation_gain_m'] or '—':7} | "
+        f"{r['suffer_score'] or '—':6} | "
+        f"{r['perceived_exertion'] or '—':3} | "
+        f"{analysis}"
+    )
+
+
+def _cycling_log_row(r: dict) -> str:
+    dist_km = (r["distance_m"] or 0) / 1000
+    analysis = (r.get("analysis_summary") or "")[:60]
+    return (
+        f"{r['date'] or '?':10s} | "
+        f"{(r['name'] or '')[:30]:30s} | "
+        f"{dist_km:8.2f} | "
+        f"{_format_duration(r['moving_time_s']):8s} | "
+        f"{_format_speed(r['avg_pace_s_per_km']):8s} | "
+        f"{r['avg_hr'] or '—':6} | "
+        f"{r['max_hr'] or '—':6} | "
+        f"{r['avg_cadence'] or '—':12} | "
+        f"{r['elevation_gain_m'] or '—':7} | "
+        f"{r['suffer_score'] or '—':6} | "
+        f"{r['perceived_exertion'] or '—':3} | "
+        f"{analysis}"
+    )
+
+
+def _hybrid_log_row(r: dict) -> str:
+    dist_km = (r["distance_m"] or 0) / 1000
+    sport = r["sport_type"] or ""
+    is_run = sport in RUN_TYPES
+    pace_speed = (
+        _format_pace(r["avg_pace_s_per_km"]) if is_run else _format_speed(r["avg_pace_s_per_km"])
+    )
+    analysis = (r.get("analysis_summary") or "")[:60]
+    return (
+        f"{r['date'] or '?':10s} | "
+        f"{sport[:10]:10s} | "
+        f"{(r['name'] or '')[:30]:30s} | "
+        f"{dist_km:8.2f} | "
+        f"{_format_duration(r['moving_time_s']):8s} | "
+        f"{pace_speed:11s} | "
+        f"{r['avg_hr'] or '—':6} | "
+        f"{r['max_hr'] or '—':6} | "
+        f"{r['avg_cadence'] or '—':7} | "
+        f"{r['elevation_gain_m'] or '—':7} | "
+        f"{r['suffer_score'] or '—':6} | "
+        f"{r['perceived_exertion'] or '—':3} | "
+        f"{analysis}"
+    )
+
+
+def _lifting_log_row(r: dict) -> str:
+    analysis = (r.get("analysis_summary") or "")[:60]
+    return (
+        f"{r['date'] or '?':10s} | "
+        f"{(r['name'] or '')[:30]:30s} | "
+        f"{_format_duration(r['moving_time_s']):8s} | "
+        f"{r['total_sets'] or '—':4} | "
+        f"{r['total_volume_kg'] or '—':10} | "
+        f"{r['perceived_exertion'] or '—':3} | "
+        f"{analysis}"
+    )
+
+
+def _make_cardio_total(label: str) -> Callable[[list[dict]], str]:
+    def total(rows: list[dict]) -> str:
+        total_km = sum((r["distance_m"] or 0) / 1000 for r in rows)
+        return f"Total: {len(rows)} {label}, {total_km:.1f} km"
+
+    return total
+
+
+def _lifting_log_total(rows: list[dict]) -> str:
+    total_volume = sum((r["total_volume_kg"] or 0) for r in rows)
+    return f"Total: {len(rows)} sessions, {total_volume:.0f} kg cumulative volume"
+
+
+# ── ModeConfig ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ModeConfig:
+    name: str
+    sport_types: frozenset[str] | None  # None = no filter (all activities, used by hybrid)
+    system_prompt: str
+    has_analysis: bool  # whether to inject the cardio metrics guide
+    hidden_tabs: frozenset[str]  # frontend tabs to hide for this mode
+    activity_label: str  # "runs", "rides", "sessions", "activities"
+    log_header: str  # column header row for training log
+    log_sep_len: int  # length of the separator line
+    format_log_row: Callable[[dict], str]
+    format_log_total: Callable[[list[dict]], str]
+    profile_section_keys: list[str]  # ordered section keys for profile_to_text
+
+
+MODES: dict[str, ModeConfig] = {
+    "running": ModeConfig(
+        name="running",
+        sport_types=RUN_TYPES,
+        system_prompt=RUNNING_SYSTEM_PROMPT,
+        has_analysis=True,
+        hidden_tabs=frozenset(),
+        activity_label="runs",
+        log_header=(
+            "DATE       | NAME                           | DIST(km) | DURATION | PACE     "
+            "| AVG HR | MAX HR | CADENCE(spm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
+        ),
+        log_sep_len=200,
+        format_log_row=_running_log_row,
+        format_log_total=_make_cardio_total("runs"),
+        profile_section_keys=[
+            "personal",
+            "running_background",
+            "personal_bests",
+            "goals",
+            "injuries_and_health",
+            "gear",
+            "nutrition_snacks",
+            "other_notes",
+        ],
+    ),
+    "cycling": ModeConfig(
+        name="cycling",
+        sport_types=CYCLE_TYPES,
+        system_prompt=CYCLING_SYSTEM_PROMPT,
+        has_analysis=True,
+        hidden_tabs=frozenset(),
+        activity_label="rides",
+        log_header=(
+            "DATE       | NAME                           | DIST(km) | DURATION | SPEED    "
+            "| AVG HR | MAX HR | CADENCE(rpm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
+        ),
+        log_sep_len=200,
+        format_log_row=_cycling_log_row,
+        format_log_total=_make_cardio_total("rides"),
+        profile_section_keys=[
+            "personal",
+            "cycling_background",
+            "cycling_bests",
+            "goals",
+            "injuries_and_health",
+            "gear",
+            "nutrition_snacks",
+            "other_notes",
+        ],
+    ),
+    "hybrid": ModeConfig(
+        name="hybrid",
+        sport_types=None,
+        system_prompt=HYBRID_SYSTEM_PROMPT,
+        has_analysis=True,
+        hidden_tabs=frozenset(),
+        activity_label="activities",
+        log_header=(
+            "DATE       | TYPE       | NAME                           | DIST(km) | DURATION "
+            "| PACE/SPEED  | AVG HR | MAX HR | CADENCE | ELEV(m) | SUFFER | RPE | ANALYSIS"
+        ),
+        log_sep_len=215,
+        format_log_row=_hybrid_log_row,
+        format_log_total=_make_cardio_total("activities"),
+        profile_section_keys=[
+            "personal",
+            "running_background",
+            "running_bests",
+            "cycling_background",
+            "cycling_bests",
+            "goals",
+            "injuries_and_health",
+            "gear",
+            "nutrition_snacks",
+            "other_notes",
+        ],
+    ),
+    "lifting": ModeConfig(
+        name="lifting",
+        sport_types=LIFT_TYPES,
+        system_prompt=LIFTING_SYSTEM_PROMPT,
+        has_analysis=False,
+        hidden_tabs=frozenset({"charts", "calendar"}),
+        activity_label="sessions",
+        log_header=(
+            "DATE       | NAME                           | DURATION | SETS | VOLUME(kg) | RPE | ANALYSIS"
+        ),
+        log_sep_len=140,
+        format_log_row=_lifting_log_row,
+        format_log_total=_lifting_log_total,
+        profile_section_keys=[
+            "personal",
+            "lifting_background",
+            "lifting_bests",
+            "goals",
+            "injuries_and_health",
+            "equipment",
+            "nutrition_snacks",
+            "other_notes",
+        ],
+    ),
+}

--- a/strides_ai/profile.py
+++ b/strides_ai/profile.py
@@ -2,6 +2,8 @@
 
 import copy
 
+from .modes import MODES
+
 # ── Per-mode default field schemas ────────────────────────────────────────────
 
 RUNNING_DEFAULTS: dict = {
@@ -148,6 +150,161 @@ def _section(title: str, lines: list[str]) -> str:
     return f"### {title}\n{body}" if body else ""
 
 
+# ── Per-section renderers ──────────────────────────────────────────────────────
+
+
+def _render_personal(fields: dict) -> str:
+    p = fields.get("personal", {})
+    lines = [
+        f"Name: {_v(p.get('name'))}" if _v(p.get("name")) else "",
+        f"Gender: {_v(p.get('gender'))}" if _v(p.get("gender")) else "",
+        f"Date of birth: {_v(p.get('date_of_birth'))}" if _v(p.get("date_of_birth")) else "",
+        f"Height: {_v(p.get('height'))}" if _v(p.get("height")) else "",
+        f"Weight: {_v(p.get('weight'))}" if _v(p.get("weight")) else "",
+        f"Max heart rate: {_v(p.get('max_hr'))} bpm" if _v(p.get("max_hr")) else "",
+    ]
+    return _section("Personal", lines)
+
+
+def _render_running_background(fields: dict) -> str:
+    rb = fields.get("running_background", {})
+    weekly = _v(rb.get("weekly_volume") or rb.get("weekly_run_volume"))
+    lines = [
+        f"Running since: {_v(rb.get('running_since'))}" if _v(rb.get("running_since")) else "",
+        f"Weekly volume: {weekly}" if weekly else "",
+        f"Background: {_v(rb.get('background'))}" if _v(rb.get("background")) else "",
+    ]
+    return _section("Running Background", lines)
+
+
+def _render_personal_bests(fields: dict) -> str:
+    pbs = fields.get("personal_bests", {})
+    lines = [
+        f"5K: {_v(pbs.get('5k'))}" if _v(pbs.get("5k")) else "",
+        f"10K: {_v(pbs.get('10k'))}" if _v(pbs.get("10k")) else "",
+        f"Half marathon: {_v(pbs.get('half_marathon'))}" if _v(pbs.get("half_marathon")) else "",
+        f"Marathon: {_v(pbs.get('marathon'))}" if _v(pbs.get("marathon")) else "",
+    ]
+    return _section("Running Personal Bests", lines)
+
+
+def _render_running_bests(fields: dict) -> str:
+    pbs = fields.get("running_bests", {})
+    lines = [
+        f"5K: {_v(pbs.get('5k'))}" if _v(pbs.get("5k")) else "",
+        f"10K: {_v(pbs.get('10k'))}" if _v(pbs.get("10k")) else "",
+        f"Half marathon: {_v(pbs.get('half_marathon'))}" if _v(pbs.get("half_marathon")) else "",
+        f"Marathon: {_v(pbs.get('marathon'))}" if _v(pbs.get("marathon")) else "",
+    ]
+    return _section("Running Personal Bests", lines)
+
+
+def _render_cycling_background(fields: dict) -> str:
+    cb = fields.get("cycling_background", {})
+    weekly = _v(cb.get("weekly_distance") or cb.get("weekly_ride_distance"))
+    lines = [
+        f"Cycling since: {_v(cb.get('cycling_since'))}" if _v(cb.get("cycling_since")) else "",
+        f"Weekly distance: {weekly}" if weekly else "",
+        f"Background: {_v(cb.get('background'))}" if _v(cb.get("background")) else "",
+    ]
+    return _section("Cycling Background", lines)
+
+
+def _render_cycling_bests(fields: dict) -> str:
+    cyb = fields.get("cycling_bests", {})
+    lines = [
+        f"FTP: {_v(cyb.get('ftp'))}" if _v(cyb.get("ftp")) else "",
+        (
+            f"Fastest century: {_v(cyb.get('fastest_century'))}"
+            if _v(cyb.get("fastest_century"))
+            else ""
+        ),
+        (
+            f"Fastest gran fondo: {_v(cyb.get('fastest_gran_fondo'))}"
+            if _v(cyb.get("fastest_gran_fondo"))
+            else ""
+        ),
+        f"Other: {_v(cyb.get('other'))}" if _v(cyb.get("other")) else "",
+    ]
+    return _section("Cycling Bests", lines)
+
+
+def _render_lifting_background(fields: dict) -> str:
+    lb = fields.get("lifting_background", {})
+    lines = [
+        f"Lifting since: {_v(lb.get('lifting_since'))}" if _v(lb.get("lifting_since")) else "",
+        (
+            f"Sessions per week: {_v(lb.get('sessions_per_week'))}"
+            if _v(lb.get("sessions_per_week"))
+            else ""
+        ),
+        f"Training style: {_v(lb.get('training_style'))}" if _v(lb.get("training_style")) else "",
+        f"Background: {_v(lb.get('background'))}" if _v(lb.get("background")) else "",
+    ]
+    return _section("Lifting Background", lines)
+
+
+def _render_lifting_bests(fields: dict) -> str:
+    lbests = fields.get("lifting_bests", {})
+    lines = [
+        f"Squat 1RM: {_v(lbests.get('squat_1rm'))}" if _v(lbests.get("squat_1rm")) else "",
+        f"Deadlift 1RM: {_v(lbests.get('deadlift_1rm'))}" if _v(lbests.get("deadlift_1rm")) else "",
+        (
+            f"Bench press 1RM: {_v(lbests.get('bench_press_1rm'))}"
+            if _v(lbests.get("bench_press_1rm"))
+            else ""
+        ),
+        (
+            f"Overhead press 1RM: {_v(lbests.get('overhead_press_1rm'))}"
+            if _v(lbests.get("overhead_press_1rm"))
+            else ""
+        ),
+        f"Other: {_v(lbests.get('other'))}" if _v(lbests.get("other")) else "",
+    ]
+    return _section("Lifting Bests", lines)
+
+
+def _render_simple(key: str, title: str) -> "Callable[[dict], str]":
+    def render(fields: dict) -> str:
+        val = _v(fields.get(key))
+        return f"### {title}\n{val}" if val else ""
+
+    return render
+
+
+def _render_nutrition(fields: dict) -> str:
+    snacks = fields.get("nutrition_snacks", [])
+    if isinstance(snacks, list):
+        items = [s.strip() for s in snacks if str(s).strip()]
+    else:
+        items = [s.strip() for s in str(snacks).splitlines() if s.strip()]
+    if not items:
+        return ""
+    bullet_list = "\n".join(f"- {s}" for s in items)
+    return f"### Preferred Nutrition & Snacks\n{bullet_list}"
+
+
+# Callable import for type hint in _render_simple
+from typing import Callable  # noqa: E402
+
+_SECTION_RENDERERS: dict[str, Callable[[dict], str]] = {
+    "personal": _render_personal,
+    "running_background": _render_running_background,
+    "personal_bests": _render_personal_bests,
+    "running_bests": _render_running_bests,
+    "cycling_background": _render_cycling_background,
+    "cycling_bests": _render_cycling_bests,
+    "lifting_background": _render_lifting_background,
+    "lifting_bests": _render_lifting_bests,
+    "goals": _render_simple("goals", "Goals"),
+    "injuries_and_health": _render_simple("injuries_and_health", "Injuries & Health"),
+    "gear": _render_simple("gear", "Gear"),
+    "equipment": _render_simple("equipment", "Equipment"),
+    "nutrition_snacks": _render_nutrition,
+    "other_notes": _render_simple("other_notes", "Other Notes"),
+}
+
+
 def profile_to_text(fields: dict | None, mode: str) -> str:
     """Convert a profile fields dict to readable text for the system prompt.
 
@@ -156,149 +313,14 @@ def profile_to_text(fields: dict | None, mode: str) -> str:
     if not fields:
         return ""
 
-    p = fields.get("personal", {})
+    cfg = MODES.get(mode, MODES["running"])
     sections: list[str] = []
-
-    # Personal
-    personal_lines = [
-        f"Name: {_v(p.get('name'))}" if _v(p.get("name")) else "",
-        f"Gender: {_v(p.get('gender'))}" if _v(p.get("gender")) else "",
-        f"Date of birth: {_v(p.get('date_of_birth'))}" if _v(p.get("date_of_birth")) else "",
-        f"Height: {_v(p.get('height'))}" if _v(p.get("height")) else "",
-        f"Weight: {_v(p.get('weight'))}" if _v(p.get("weight")) else "",
-        f"Max heart rate: {_v(p.get('max_hr'))} bpm" if _v(p.get("max_hr")) else "",
-    ]
-    s = _section("Personal", personal_lines)
-    if s:
-        sections.append(s)
-
-    if mode in ("running", "hybrid"):
-        rb = fields.get("running_background", {})
-        rb_lines = [
-            f"Running since: {_v(rb.get('running_since'))}" if _v(rb.get("running_since")) else "",
-            (
-                f"Weekly volume: {_v(rb.get('weekly_volume') or rb.get('weekly_run_volume'))}"
-                if _v(rb.get("weekly_volume") or rb.get("weekly_run_volume"))
-                else ""
-            ),
-            f"Background: {_v(rb.get('background'))}" if _v(rb.get("background")) else "",
-        ]
-        s = _section("Running Background", rb_lines)
-        if s:
-            sections.append(s)
-
-        pbs = fields.get("personal_bests" if mode == "running" else "running_bests", {})
-        pb_lines = [
-            f"5K: {_v(pbs.get('5k'))}" if _v(pbs.get("5k")) else "",
-            f"10K: {_v(pbs.get('10k'))}" if _v(pbs.get("10k")) else "",
-            (
-                f"Half marathon: {_v(pbs.get('half_marathon'))}"
-                if _v(pbs.get("half_marathon"))
-                else ""
-            ),
-            f"Marathon: {_v(pbs.get('marathon'))}" if _v(pbs.get("marathon")) else "",
-        ]
-        s = _section("Running Personal Bests", pb_lines)
-        if s:
-            sections.append(s)
-
-    if mode == "lifting":
-        lb = fields.get("lifting_background", {})
-        lb_lines = [
-            f"Lifting since: {_v(lb.get('lifting_since'))}" if _v(lb.get("lifting_since")) else "",
-            (
-                f"Sessions per week: {_v(lb.get('sessions_per_week'))}"
-                if _v(lb.get("sessions_per_week"))
-                else ""
-            ),
-            (
-                f"Training style: {_v(lb.get('training_style'))}"
-                if _v(lb.get("training_style"))
-                else ""
-            ),
-            f"Background: {_v(lb.get('background'))}" if _v(lb.get("background")) else "",
-        ]
-        s = _section("Lifting Background", lb_lines)
-        if s:
-            sections.append(s)
-
-        lbests = fields.get("lifting_bests", {})
-        lbest_lines = [
-            f"Squat 1RM: {_v(lbests.get('squat_1rm'))}" if _v(lbests.get("squat_1rm")) else "",
-            (
-                f"Deadlift 1RM: {_v(lbests.get('deadlift_1rm'))}"
-                if _v(lbests.get("deadlift_1rm"))
-                else ""
-            ),
-            (
-                f"Bench press 1RM: {_v(lbests.get('bench_press_1rm'))}"
-                if _v(lbests.get("bench_press_1rm"))
-                else ""
-            ),
-            (
-                f"Overhead press 1RM: {_v(lbests.get('overhead_press_1rm'))}"
-                if _v(lbests.get("overhead_press_1rm"))
-                else ""
-            ),
-            f"Other: {_v(lbests.get('other'))}" if _v(lbests.get("other")) else "",
-        ]
-        s = _section("Lifting Bests", lbest_lines)
-        if s:
-            sections.append(s)
-
-    if mode in ("cycling", "hybrid"):
-        cb = fields.get("cycling_background", {})
-        cb_lines = [
-            f"Cycling since: {_v(cb.get('cycling_since'))}" if _v(cb.get("cycling_since")) else "",
-            (
-                f"Weekly distance: {_v(cb.get('weekly_distance') or cb.get('weekly_ride_distance'))}"
-                if _v(cb.get("weekly_distance") or cb.get("weekly_ride_distance"))
-                else ""
-            ),
-            f"Background: {_v(cb.get('background'))}" if _v(cb.get("background")) else "",
-        ]
-        s = _section("Cycling Background", cb_lines)
-        if s:
-            sections.append(s)
-
-        cyb = fields.get("cycling_bests", {})
-        cyb_lines = [
-            f"FTP: {_v(cyb.get('ftp'))}" if _v(cyb.get("ftp")) else "",
-            (
-                f"Fastest century: {_v(cyb.get('fastest_century'))}"
-                if _v(cyb.get("fastest_century"))
-                else ""
-            ),
-            (
-                f"Fastest gran fondo: {_v(cyb.get('fastest_gran_fondo'))}"
-                if _v(cyb.get("fastest_gran_fondo"))
-                else ""
-            ),
-            f"Other: {_v(cyb.get('other'))}" if _v(cyb.get("other")) else "",
-        ]
-        s = _section("Cycling Bests", cyb_lines)
-        if s:
-            sections.append(s)
-
-    for key, title in [
-        ("goals", "Goals"),
-        ("injuries_and_health", "Injuries & Health"),
-        ("gear", "Gear"),
-        ("equipment", "Equipment"),
-        ("other_notes", "Other Notes"),
-    ]:
-        val = _v(fields.get(key))
-        if val:
-            sections.append(f"### {title}\n{val}")
-
-    snacks = fields.get("nutrition_snacks", [])
-    if isinstance(snacks, list):
-        snack_items = [s.strip() for s in snacks if str(s).strip()]
-    else:
-        snack_items = [s.strip() for s in str(snacks).splitlines() if s.strip()]
-    if snack_items:
-        bullet_list = "\n".join(f"- {s}" for s in snack_items)
-        sections.append(f"### Preferred Nutrition & Snacks\n{bullet_list}")
+    for key in cfg.profile_section_keys:
+        renderer = _SECTION_RENDERERS.get(key)
+        if renderer:
+            rendered = renderer(fields)
+            if rendered:
+                sections.append(rendered)
 
     if not sections:
         return ""

--- a/tests/test_coach.py
+++ b/tests/test_coach.py
@@ -5,16 +5,14 @@ from datetime import date, timedelta
 import pytest
 
 from strides_ai import db
-from strides_ai.coach import (
+from strides_ai.coach import build_initial_history, build_system, build_training_log
+from strides_ai.modes import (
     CYCLING_SYSTEM_PROMPT,
     HYBRID_SYSTEM_PROMPT,
     RUNNING_SYSTEM_PROMPT,
     _format_duration,
     _format_pace,
     _format_speed,
-    build_initial_history,
-    build_system,
-    build_training_log,
 )
 
 # ── _format_pace ──────────────────────────────────────────────────────────────

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -106,18 +106,20 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 const VALID_TABS = new Set<string>([...TABS.map((t) => t.id), "settings"]);
-const HIDDEN_IN_LIFTING = new Set<Tab>(["charts", "calendar"]);
 
 function tabFromHash(): Tab {
   const hash = location.hash.slice(1);
   return VALID_TABS.has(hash) ? (hash as Tab) : "chat";
 }
 
+type ModeMeta = { activity_label: string; hidden_tabs: string[]; has_analysis: boolean };
+
 export default function App() {
   const [tab, setTab] = useState<Tab>(tabFromHash);
   const [mode, setMode] = useState<Mode>("running");
   const [modeLoaded, setModeLoaded] = useState(false);
   const [supportsAttachments, setSupportsAttachments] = useState(false);
+  const [modeMeta, setModeMeta] = useState<Record<string, ModeMeta>>({});
 
   useEffect(() => {
     const onHashChange = () => setTab(tabFromHash());
@@ -125,12 +127,15 @@ export default function App() {
     return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
 
-  // Load persisted mode from server on mount
+  // Load persisted mode and mode metadata from server on mount
   useEffect(() => {
-    fetch("/api/settings")
-      .then((r) => r.json())
-      .then((data: { mode: Mode }) => {
-        if (data.mode) setMode(data.mode);
+    Promise.all([
+      fetch("/api/settings").then((r) => r.json()),
+      fetch("/api/modes").then((r) => r.json()),
+    ])
+      .then(([settings, modes]: [{ mode: Mode }, Record<string, ModeMeta>]) => {
+        if (settings.mode) setMode(settings.mode);
+        setModeMeta(modes);
       })
       .catch(() => {})
       .finally(() => setModeLoaded(true));
@@ -154,9 +159,11 @@ export default function App() {
 
   const theme = THEMES[mode];
 
+  const hiddenTabs = new Set<Tab>((modeMeta[mode]?.hidden_tabs ?? []) as Tab[]);
+
   // Redirect away from tabs that aren't available in the current mode
   useEffect(() => {
-    if (mode === "lifting" && HIDDEN_IN_LIFTING.has(tab)) {
+    if (hiddenTabs.has(tab)) {
       navigate("chat");
     }
   }, [mode]);
@@ -169,7 +176,7 @@ export default function App() {
     );
   }
 
-  const visibleTabs = TABS.filter((t) => mode !== "lifting" || !HIDDEN_IN_LIFTING.has(t.id));
+  const visibleTabs = TABS.filter((t) => !hiddenTabs.has(t.id as Tab));
   const allNavTabs: { id: Tab; label: string }[] = [...visibleTabs, { id: "settings", label: "Settings" }];
   const mobileNavTabs = allNavTabs.filter((t) => t.id !== "calendar");
 


### PR DESCRIPTION
## Summary

- Introduces `strides_ai/modes.py` with a `ModeConfig` dataclass — one entry per coaching mode (running, cycling, hybrid, lifting). This is now the single source of truth: adding a new mode means adding one `ModeConfig` entry, touching nothing else.
- Eliminates 15+ scattered `if mode == "..."` branches across `coach.py`, `profile.py`, and `db/activities.py`
- `build_training_log()` in `coach.py` reduced from a 95-line if/elif block to 5 lines using per-mode log formatters defined in `modes.py`
- `profile_to_text()` in `profile.py` replaced its 100-line if/elif block with a `SECTION_RENDERERS` dict iterated over `cfg.profile_section_keys`
- `get_for_mode()` in `db/activities.py` reduced from 16 lines to 5 — `sport_types=None` means no filter (hybrid mode)
- Adds `GET /api/modes` endpoint returning `hidden_tabs` and `activity_label` per mode
- Frontend `App.tsx` replaces the hardcoded `HIDDEN_IN_LIFTING` set with server-driven `hidden_tabs` from `/api/modes`
- Tests updated to import prompts and format helpers from `modes` (canonical location) rather than `coach`

This is Option A of the two-phase refactor plan. Option B (separating DataSource from CoachingMode) is documented in the plan file and can follow once this lands.

## Test plan
- [ ] `make test` — 291 tests, all passing on this branch
- [ ] Start app (`make dev`) and switch between all 4 modes — verify correct system prompt, training log format, and profile sections load
- [ ] Verify lifting mode hides Charts and Calendar tabs; other modes show them (now server-driven)
- [ ] Check `GET /api/modes` returns expected shape for all 4 modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)