### PR TITLE
feat(profile): add focus/style dropdowns to running, cycling, and lifting profiles

### DIFF
--- a/strides_ai/profile.py
+++ b/strides_ai/profile.py
@@ -18,6 +18,7 @@ RUNNING_DEFAULTS: dict = {
     "running_background": {
         "running_since": "",
         "weekly_volume": "",
+        "running_focus": "",
         "background": "",
     },
     "personal_bests": {
@@ -45,6 +46,7 @@ CYCLING_DEFAULTS: dict = {
     "cycling_background": {
         "cycling_since": "",
         "weekly_distance": "",
+        "cycling_focus": "",
         "background": "",
     },
     "cycling_bests": {
@@ -166,12 +168,27 @@ def _render_personal(fields: dict) -> str:
     return _section("Personal", lines)
 
 
+_RUNNING_FOCUS_LABELS = {
+    "fitness": "Fitness & General Health",
+    "road_racing": "Road Racing (5K – Marathon)",
+    "marathon": "Marathon Training",
+    "trail": "Trail Running",
+    "ultra": "Ultra Running",
+    "track": "Track & Speed",
+    "beginner": "Beginner / Return to Running",
+    "multi_sport": "Multi-Sport / Triathlon",
+}
+
+
 def _render_running_background(fields: dict) -> str:
     rb = fields.get("running_background", {})
     weekly = _v(rb.get("weekly_volume") or rb.get("weekly_run_volume"))
+    focus_key = _v(rb.get("running_focus"))
+    focus_label = _RUNNING_FOCUS_LABELS.get(focus_key, focus_key)
     lines = [
         f"Running since: {_v(rb.get('running_since'))}" if _v(rb.get("running_since")) else "",
         f"Weekly volume: {weekly}" if weekly else "",
+        f"Running focus: {focus_label}" if focus_key else "",
         f"Background: {_v(rb.get('background'))}" if _v(rb.get("background")) else "",
     ]
     return _section("Running Background", lines)
@@ -199,12 +216,38 @@ def _render_running_bests(fields: dict) -> str:
     return _section("Running Personal Bests", lines)
 
 
+_CYCLING_FOCUS_LABELS = {
+    "fitness": "Fitness & General Health",
+    "road_racing": "Road Racing / Criteriums",
+    "gran_fondo": "Gran Fondo / Sportive",
+    "time_trial": "Time Trial",
+    "mountain_biking": "Mountain Biking",
+    "gravel": "Gravel & Adventure",
+    "triathlon": "Triathlon / Multi-Sport",
+    "beginner": "Beginner / Return to Cycling",
+}
+
+_LIFTING_STYLE_LABELS = {
+    "general_strength": "General Strength",
+    "powerlifting": "Powerlifting",
+    "bodybuilding": "Bodybuilding / Hypertrophy",
+    "olympic": "Olympic Weightlifting",
+    "crossfit": "CrossFit / Functional Fitness",
+    "calisthenics": "Calisthenics / Bodyweight",
+    "athletic": "Athletic Performance",
+    "beginner": "Beginner / Getting Started",
+}
+
+
 def _render_cycling_background(fields: dict) -> str:
     cb = fields.get("cycling_background", {})
     weekly = _v(cb.get("weekly_distance") or cb.get("weekly_ride_distance"))
+    focus_key = _v(cb.get("cycling_focus"))
+    focus_label = _CYCLING_FOCUS_LABELS.get(focus_key, focus_key)
     lines = [
         f"Cycling since: {_v(cb.get('cycling_since'))}" if _v(cb.get("cycling_since")) else "",
         f"Weekly distance: {weekly}" if weekly else "",
+        f"Cycling focus: {focus_label}" if focus_key else "",
         f"Background: {_v(cb.get('background'))}" if _v(cb.get("background")) else "",
     ]
     return _section("Cycling Background", lines)
@@ -231,6 +274,8 @@ def _render_cycling_bests(fields: dict) -> str:
 
 def _render_lifting_background(fields: dict) -> str:
     lb = fields.get("lifting_background", {})
+    style_key = _v(lb.get("training_style"))
+    style_label = _LIFTING_STYLE_LABELS.get(style_key, style_key)
     lines = [
         f"Lifting since: {_v(lb.get('lifting_since'))}" if _v(lb.get("lifting_since")) else "",
         (
@@ -238,7 +283,7 @@ def _render_lifting_background(fields: dict) -> str:
             if _v(lb.get("sessions_per_week"))
             else ""
         ),
-        f"Training style: {_v(lb.get('training_style'))}" if _v(lb.get("training_style")) else "",
+        f"Training style: {style_label}" if style_key else "",
         f"Background: {_v(lb.get('background'))}" if _v(lb.get("background")) else "",
     ]
     return _section("Lifting Background", lines)

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -387,6 +387,26 @@ export default function Profile({ mode, theme }: Props) {
                     placeholder="e.g. 50 km/week"
                     focusClass={focusClass}
                   />
+                  {mode === "running" && (
+                    <div className="col-span-2 flex flex-col gap-1">
+                      <label className="text-xs font-medium text-gray-400">Running Focus</label>
+                      <select
+                        value={fields.running_background?.running_focus ?? ""}
+                        onChange={(e) => setNested("running_background", "running_focus", e.target.value)}
+                        className={`rounded-md bg-gray-900 border border-gray-700 px-3 py-2 text-sm text-gray-100 focus:outline-none ${focusClass}`}
+                      >
+                        <option value="">Select…</option>
+                        <option value="fitness">Fitness &amp; General Health</option>
+                        <option value="road_racing">Road Racing (5K – Marathon)</option>
+                        <option value="marathon">Marathon Training</option>
+                        <option value="trail">Trail Running</option>
+                        <option value="ultra">Ultra Running</option>
+                        <option value="track">Track &amp; Speed</option>
+                        <option value="beginner">Beginner / Return to Running</option>
+                        <option value="multi_sport">Multi-Sport / Triathlon</option>
+                      </select>
+                    </div>
+                  )}
                 </div>
                 <TextArea
                   label="Background"
@@ -442,6 +462,26 @@ export default function Profile({ mode, theme }: Props) {
                     placeholder="e.g. 150 km/week"
                     focusClass={focusClass}
                   />
+                  {mode === "cycling" && (
+                    <div className="col-span-2 flex flex-col gap-1">
+                      <label className="text-xs font-medium text-gray-400">Cycling Focus</label>
+                      <select
+                        value={fields.cycling_background?.cycling_focus ?? ""}
+                        onChange={(e) => setNested("cycling_background", "cycling_focus", e.target.value)}
+                        className={`rounded-md bg-gray-900 border border-gray-700 px-3 py-2 text-sm text-gray-100 focus:outline-none ${focusClass}`}
+                      >
+                        <option value="">Select…</option>
+                        <option value="fitness">Fitness &amp; General Health</option>
+                        <option value="road_racing">Road Racing / Criteriums</option>
+                        <option value="gran_fondo">Gran Fondo / Sportive</option>
+                        <option value="time_trial">Time Trial</option>
+                        <option value="mountain_biking">Mountain Biking</option>
+                        <option value="gravel">Gravel &amp; Adventure</option>
+                        <option value="triathlon">Triathlon / Multi-Sport</option>
+                        <option value="beginner">Beginner / Return to Cycling</option>
+                      </select>
+                    </div>
+                  )}
                 </div>
                 <TextArea
                   label="Background"
@@ -463,6 +503,56 @@ export default function Profile({ mode, theme }: Props) {
                 <Field label="Fastest century" value={fields.cycling_bests?.fastest_century ?? ""} onChange={(v) => setNested("cycling_bests", "fastest_century", v)} placeholder="e.g. 3:45:00" focusClass={focusClass} />
                 <Field label="Fastest gran fondo" value={fields.cycling_bests?.fastest_gran_fondo ?? ""} onChange={(v) => setNested("cycling_bests", "fastest_gran_fondo", v)} placeholder="e.g. 5:30:00" focusClass={focusClass} />
                 <Field label="Other" value={fields.cycling_bests?.other ?? ""} onChange={(v) => setNested("cycling_bests", "other", v)} placeholder="e.g. KOM on local climb" focusClass={focusClass} />
+              </div>
+            </Section>
+          )}
+
+          {/* Lifting Background — lifting only */}
+          {mode === "lifting" && (
+            <Section title="Lifting Background">
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <Field
+                    label="Lifting since"
+                    value={fields.lifting_background?.lifting_since ?? ""}
+                    onChange={(v) => setNested("lifting_background", "lifting_since", v)}
+                    placeholder="e.g. 2019"
+                    focusClass={focusClass}
+                  />
+                  <Field
+                    label="Sessions per week"
+                    value={fields.lifting_background?.sessions_per_week ?? ""}
+                    onChange={(v) => setNested("lifting_background", "sessions_per_week", v)}
+                    placeholder="e.g. 4"
+                    focusClass={focusClass}
+                  />
+                  <div className="col-span-2 flex flex-col gap-1">
+                    <label className="text-xs font-medium text-gray-400">Training Style</label>
+                    <select
+                      value={fields.lifting_background?.training_style ?? ""}
+                      onChange={(e) => setNested("lifting_background", "training_style", e.target.value)}
+                      className={`rounded-md bg-gray-900 border border-gray-700 px-3 py-2 text-sm text-gray-100 focus:outline-none ${focusClass}`}
+                    >
+                      <option value="">Select…</option>
+                      <option value="general_strength">General Strength</option>
+                      <option value="powerlifting">Powerlifting</option>
+                      <option value="bodybuilding">Bodybuilding / Hypertrophy</option>
+                      <option value="olympic">Olympic Weightlifting</option>
+                      <option value="crossfit">CrossFit / Functional Fitness</option>
+                      <option value="calisthenics">Calisthenics / Bodyweight</option>
+                      <option value="athletic">Athletic Performance</option>
+                      <option value="beginner">Beginner / Getting Started</option>
+                    </select>
+                  </div>
+                </div>
+                <TextArea
+                  label="Background"
+                  value={fields.lifting_background?.background ?? ""}
+                  onChange={(v) => setNested("lifting_background", "background", v)}
+                  placeholder="How you got into lifting, programs you've run, gym setup…"
+                  rows={3}
+                  focusClass={focusClass}
+                />
               </div>
             </Section>
           )}


### PR DESCRIPTION
## Summary
- Added **Running Focus** dropdown to the running profile (Fitness, Road Racing, Marathon Training, Trail, Ultra, Track, Beginner, Multi-Sport)
- Added **Cycling Focus** dropdown to the cycling profile (Fitness, Road Racing/Criteriums, Gran Fondo, Time Trial, Mountain Biking, Gravel, Triathlon, Beginner)
- Added **Training Style** dropdown to the lifting profile (General Strength, Powerlifting, Bodybuilding, Olympic Weightlifting, CrossFit, Calisthenics, Athletic Performance, Beginner)
- Added the **Lifting Background** section to the profile UI (was missing entirely — now shows Lifting since, Sessions per week, Training Style, and Background fields)
- Each dropdown value is mapped to a readable label in `profile.py` before being injected into the LLM system prompt

## Test plan
- [x] Switch to each mode (running, cycling, lifting) in settings and open the profile page — confirm the focus/style dropdown appears in the background section
- [x] Select an option, save, reload — confirm the value persists
- [x] Start a chat and ask "What do you know about my profile?" — confirm the focus/style label appears in the response
- [x] Verify tests still pass: `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)