### PR TITLE
feat(settings): add per-mode coach voice setting

### DIFF
--- a/strides_ai/api/routers/chat.py
+++ b/strides_ai/api/routers/chat.py
@@ -88,12 +88,14 @@ async def chat(
     memories = mem_crud.get_all(session)
     profile_fields = prof_crud.get_fields(session, mode)
     profile = profile_to_text(profile_fields, mode)
+    coach_voice = (profile_fields or {}).get("coach_voice", "")
     activities = [r.model_dump() for r in act_crud.get_for_mode(session, mode)]
     system = build_system(
         profile,
         [r.model_dump() for r in memories],
         mode=mode,
         activities=activities,
+        coach_voice=coach_voice,
     )
 
     conv_crud.save(session, "user", saved_message, mode=mode)

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -63,6 +63,8 @@ def build_system(
     prompt = cfg.system_prompt
 
     voice_block = VOICE_INSTRUCTIONS.get(coach_voice, "")
+    if not voice_block and coach_voice:
+        voice_block = f"## Coaching Voice\n{coach_voice}"
     if voice_block:
         prompt += f"\n\n{voice_block}"
 

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -11,15 +11,60 @@ RECALL_MESSAGES = 40
 # The full training log is seeded once in conversation history via build_initial_history.
 RECENT_ACTIVITIES_IN_SYSTEM = 30
 
+VOICE_INSTRUCTIONS: dict[str, str] = {
+    "supportive": (
+        "## Coaching Voice\n"
+        "Communicate with warmth and encouragement. Celebrate every win, no matter how small. "
+        "Emphasise progress over performance. Frame setbacks constructively and use inclusive, "
+        "affirming language throughout."
+    ),
+    "motivational": (
+        "## Coaching Voice\n"
+        "Be high-energy and inspirational. Push the athlete toward their goals with genuine excitement. "
+        "Use strong, vivid language. Remind them why they started and what they're capable of. "
+        "Keep the energy up throughout every response."
+    ),
+    "technical": (
+        "## Coaching Voice\n"
+        "Be analytical and data-driven. Lean into metrics, zones, ratios, and trends. "
+        "Minimise small talk — get to the numbers quickly. Use precise terminology "
+        "(e.g. cardiac decoupling, lactate threshold, progressive overload). "
+        "Support every recommendation with data from the training log."
+    ),
+    "aggressive": (
+        "## Coaching Voice\n"
+        "Be direct and demanding. No sugarcoating — if the data shows underperformance, say so. "
+        "Push harder. Keep responses concise and action-oriented. "
+        "Focus on results, not feelings."
+    ),
+    "beginner_friendly": (
+        "## Coaching Voice\n"
+        "Be patient and educational. Avoid jargon — explain any technical terms you use. "
+        "Break advice into simple, concrete steps. Reassure the athlete that progress takes time "
+        "and that consistency matters more than perfection. Prioritise clarity over brevity."
+    ),
+    "conversational": (
+        "## Coaching Voice\n"
+        "Be casual and relaxed, like talking to a training buddy. Keep formality low. "
+        "Use natural, colloquial language and feel free to be a bit chatty. "
+        "Make the athlete feel like they're having a conversation, not receiving a lecture."
+    ),
+}
+
 
 def build_system(
     profile: str,
     memories: list[dict],
     mode: str = "running",
     activities: list | None = None,
+    coach_voice: str = "",
 ) -> str:
     cfg = MODES.get(mode, MODES["running"])
     prompt = cfg.system_prompt
+
+    voice_block = VOICE_INSTRUCTIONS.get(coach_voice, "")
+    if voice_block:
+        prompt += f"\n\n{voice_block}"
 
     now = datetime.now().astimezone()
     day_str = now.strftime("%A, %B %-d, %Y")

--- a/strides_ai/profile.py
+++ b/strides_ai/profile.py
@@ -32,6 +32,7 @@ RUNNING_DEFAULTS: dict = {
     "gear": "",
     "nutrition_snacks": [],
     "other_notes": "",
+    "coach_voice": "",
 }
 
 CYCLING_DEFAULTS: dict = {
@@ -60,6 +61,7 @@ CYCLING_DEFAULTS: dict = {
     "gear": "",
     "nutrition_snacks": [],
     "other_notes": "",
+    "coach_voice": "",
 }
 
 HYBRID_DEFAULTS: dict = {
@@ -98,6 +100,7 @@ HYBRID_DEFAULTS: dict = {
     "gear": "",
     "nutrition_snacks": [],
     "other_notes": "",
+    "coach_voice": "",
 }
 
 LIFTING_DEFAULTS: dict = {
@@ -126,6 +129,7 @@ LIFTING_DEFAULTS: dict = {
     "equipment": "",  # home gym, commercial gym, etc.
     "nutrition_snacks": [],
     "other_notes": "",
+    "coach_voice": "",
 }
 
 _DEFAULTS = {

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -20,6 +20,7 @@ def test_get_default_fields_running_keys():
         "gear",
         "nutrition_snacks",
         "other_notes",
+        "coach_voice",
     }
 
 
@@ -34,6 +35,7 @@ def test_get_default_fields_cycling_keys():
         "gear",
         "nutrition_snacks",
         "other_notes",
+        "coach_voice",
     }
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -72,6 +72,7 @@ def test_get_default_fields_lifting_keys():
         "equipment",
         "nutrition_snacks",
         "other_notes",
+        "coach_voice",
     }
 
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -74,7 +74,10 @@ const VOICE_OPTIONS: { value: string; label: string; description: string }[] = [
   { value: "aggressive", label: "Aggressive", description: "Direct, demanding, no sugarcoating" },
   { value: "beginner_friendly", label: "Beginner Friendly", description: "Patient, educational, jargon-free" },
   { value: "conversational", label: "Conversational", description: "Casual, relaxed, like a training buddy" },
+  { value: "custom", label: "Custom", description: "Write your own coaching voice instruction" },
 ];
+
+const PRESET_VOICE_VALUES = new Set(VOICE_OPTIONS.map((o) => o.value).filter((v) => v !== "custom"));
 
 export default function Settings({ mode, setMode, theme, onProviderChanged }: Props) {
   const [syncState, setSyncState] = useState<SyncState>("idle");
@@ -86,6 +89,8 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
   const [providerModels, setProviderModels] = useState<Record<string, ProviderModel[]>>({});
   const [changingModel, setChangingModel] = useState(false);
   const [voiceByMode, setVoiceByMode] = useState<Record<string, string>>({});
+  const [customText, setCustomText] = useState<Record<string, string>>({});
+  const [customSelected, setCustomSelected] = useState<Record<string, boolean>>({});
   const [voiceSaving, setVoiceSaving] = useState(false);
 
   useEffect(() => {
@@ -97,7 +102,12 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
           .then(({ fields }) => [m, (fields?.coach_voice as string) ?? ""] as [string, string])
           .catch(() => [m, ""] as [string, string])
       )
-    ).then((entries) => setVoiceByMode(Object.fromEntries(entries)));
+    ).then((entries) => {
+      setVoiceByMode(Object.fromEntries(entries));
+      const customEntries = entries.filter(([, v]) => v && !PRESET_VOICE_VALUES.has(v));
+      setCustomText(Object.fromEntries(customEntries.map(([m, v]) => [m, v])));
+      setCustomSelected(Object.fromEntries(customEntries.map(([m]) => [m, true])));
+    });
   }, []);
 
   useEffect(() => {
@@ -260,6 +270,9 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
             </p>
             {(() => {
               const card = MODE_CARDS.find((c) => c.id === mode)!;
+              const stored = voiceByMode[card.id] ?? "";
+              const isCustom = customSelected[card.id] ?? false;
+              const selectValue = isCustom ? "custom" : stored;
               return (
                 <div className="p-4 rounded-lg border border-gray-700 bg-gray-900">
                   <div className="flex items-center gap-2 mb-2">
@@ -267,8 +280,15 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
                     <span className={`text-xs font-medium ${card.accentClass}`}>{card.label}</span>
                   </div>
                   <select
-                    value={voiceByMode[card.id] ?? ""}
-                    onChange={(e) => handleVoiceChange(card.id, e.target.value)}
+                    value={selectValue}
+                    onChange={(e) => {
+                      if (e.target.value === "custom") {
+                        setCustomSelected((prev) => ({ ...prev, [card.id]: true }));
+                      } else {
+                        setCustomSelected((prev) => ({ ...prev, [card.id]: false }));
+                        handleVoiceChange(card.id, e.target.value);
+                      }
+                    }}
                     disabled={voiceSaving}
                     className="w-full bg-gray-800 text-gray-300 text-xs rounded px-2 py-1.5 border border-gray-700 focus:outline-none focus:border-gray-500 disabled:opacity-50"
                   >
@@ -278,6 +298,19 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
                       </option>
                     ))}
                   </select>
+                  {(selectValue === "custom") && (
+                    <textarea
+                      value={customText[card.id] ?? ""}
+                      onChange={(e) =>
+                        setCustomText((prev) => ({ ...prev, [card.id]: e.target.value }))
+                      }
+                      onBlur={() => handleVoiceChange(card.id, customText[card.id] ?? "")}
+                      disabled={voiceSaving}
+                      placeholder="Describe how your coach should communicate…"
+                      rows={3}
+                      className="mt-2 w-full bg-gray-800 text-gray-300 text-xs rounded px-2 py-1.5 border border-gray-700 focus:outline-none focus:border-gray-500 disabled:opacity-50 resize-none placeholder-gray-600"
+                    />
+                  )}
                 </div>
               );
             })()}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -146,7 +146,6 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
       // best-effort; switch mode locally regardless
     }
     setMode(newMode);
-    location.hash = "chat";
   }
 
   async function handleProviderChange(providerId: string) {
@@ -259,9 +258,10 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
             <p className="text-xs text-gray-600 mb-3">
               Adjust how your coach communicates. Each mode can have a different voice.
             </p>
-            <div className="space-y-3">
-              {MODE_CARDS.map((card) => (
-                <div key={card.id} className="p-4 rounded-lg border border-gray-700 bg-gray-900">
+            {(() => {
+              const card = MODE_CARDS.find((c) => c.id === mode)!;
+              return (
+                <div className="p-4 rounded-lg border border-gray-700 bg-gray-900">
                   <div className="flex items-center gap-2 mb-2">
                     <span className={`w-2 h-2 rounded-full shrink-0 ${card.dotClass}`} />
                     <span className={`text-xs font-medium ${card.accentClass}`}>{card.label}</span>
@@ -279,8 +279,8 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
                     ))}
                   </select>
                 </div>
-              ))}
-            </div>
+              );
+            })()}
           </section>
 
           <section>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -66,6 +66,16 @@ const MODE_CARDS: {
 
 type SyncState = "idle" | "syncing" | "done" | "error";
 
+const VOICE_OPTIONS: { value: string; label: string; description: string }[] = [
+  { value: "", label: "Default", description: "Uses the mode's standard coaching style" },
+  { value: "supportive", label: "Supportive", description: "Warm, encouraging, celebrates every win" },
+  { value: "motivational", label: "Motivational", description: "High-energy, inspirational, pushes toward goals" },
+  { value: "technical", label: "Technical", description: "Analytical, data-driven, metrics-focused" },
+  { value: "aggressive", label: "Aggressive", description: "Direct, demanding, no sugarcoating" },
+  { value: "beginner_friendly", label: "Beginner Friendly", description: "Patient, educational, jargon-free" },
+  { value: "conversational", label: "Conversational", description: "Casual, relaxed, like a training buddy" },
+];
+
 export default function Settings({ mode, setMode, theme, onProviderChanged }: Props) {
   const [syncState, setSyncState] = useState<SyncState>("idle");
   const [syncCount, setSyncCount] = useState<number | null>(null);
@@ -75,6 +85,20 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
   const [switchingProvider, setSwitchingProvider] = useState(false);
   const [providerModels, setProviderModels] = useState<Record<string, ProviderModel[]>>({});
   const [changingModel, setChangingModel] = useState(false);
+  const [voiceByMode, setVoiceByMode] = useState<Record<string, string>>({});
+  const [voiceSaving, setVoiceSaving] = useState(false);
+
+  useEffect(() => {
+    const modes: Mode[] = ["running", "cycling", "hybrid", "lifting"];
+    Promise.all(
+      modes.map((m) =>
+        fetch(`/api/profile?mode=${m}`)
+          .then((r) => r.json())
+          .then(({ fields }) => [m, (fields?.coach_voice as string) ?? ""] as [string, string])
+          .catch(() => [m, ""] as [string, string])
+      )
+    ).then((entries) => setVoiceByMode(Object.fromEntries(entries)));
+  }, []);
 
   useEffect(() => {
     fetch("/api/providers")
@@ -95,6 +119,21 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
       })
       .catch(() => {});
   }, []);
+
+  async function handleVoiceChange(targetMode: Mode, voice: string) {
+    setVoiceSaving(true);
+    setVoiceByMode((prev) => ({ ...prev, [targetMode]: voice }));
+    try {
+      const { fields } = await fetch(`/api/profile?mode=${targetMode}`).then((r) => r.json());
+      await fetch(`/api/profile?mode=${targetMode}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fields: { ...fields, coach_voice: voice } }),
+      });
+    } finally {
+      setVoiceSaving(false);
+    }
+  }
 
   async function handleModeChange(newMode: Mode) {
     try {
@@ -210,6 +249,37 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
                   </button>
                 );
               })}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+              Coach Voice
+            </h3>
+            <p className="text-xs text-gray-600 mb-3">
+              Adjust how your coach communicates. Each mode can have a different voice.
+            </p>
+            <div className="space-y-3">
+              {MODE_CARDS.map((card) => (
+                <div key={card.id} className="p-4 rounded-lg border border-gray-700 bg-gray-900">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className={`w-2 h-2 rounded-full shrink-0 ${card.dotClass}`} />
+                    <span className={`text-xs font-medium ${card.accentClass}`}>{card.label}</span>
+                  </div>
+                  <select
+                    value={voiceByMode[card.id] ?? ""}
+                    onChange={(e) => handleVoiceChange(card.id, e.target.value)}
+                    disabled={voiceSaving}
+                    className="w-full bg-gray-800 text-gray-300 text-xs rounded px-2 py-1.5 border border-gray-700 focus:outline-none focus:border-gray-500 disabled:opacity-50"
+                  >
+                    {VOICE_OPTIONS.map((v) => (
+                      <option key={v.value} value={v.value}>
+                        {v.label}{v.description ? ` — ${v.description}` : ""}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ))}
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- Adds a **Coach Voice** section to the Settings page, scoped to the currently active mode (instead of showing all modes at once)
- Six preset voices: Supportive, Motivational, Technical, Aggressive, Beginner Friendly, Conversational — each injects a tailored instruction block into the LLM system prompt
- **Custom voice**: selecting "Custom" reveals a textarea where you can write your own coaching instruction; saved on blur and injected directly into the system prompt
- Voice preference is stored as \`coach_voice\` in each mode's profile row — presets store the key, custom stores the raw text
- Switching coaching mode no longer redirects to chat; the user stays on the Settings page

## Test plan
- [ ] \`make test\` passes
- [ ] Open Settings → confirm "Coach Voice" shows only the active mode's dropdown
- [ ] Switch modes — confirm the dropdown updates and you stay on Settings
- [ ] Select a preset voice, go to chat, send a message — verify tone matches
- [ ] Select "Custom", type an instruction, click away — verify it saves and is reflected in chat
- [ ] Reload the page — confirm preset and custom selections are both persisted
- [ ] Confirm voice settings are independent per mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)