### PR TITLE
test: audit and tighten unit test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Shared fixtures for strides-ai tests."""
 
-import sqlite3
 from pathlib import Path
 
 import pytest
@@ -60,29 +59,3 @@ def sample_cycling_activity():
         "perceived_exertion": 6.0,
         "sport_type": "Ride",
     }
-
-
-@pytest.fixture
-def activity_row():
-    """A sqlite3.Row-compatible dict for coach/chart tests.
-
-    Uses a real in-memory connection so the value behaves exactly like a Row.
-    """
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
-    conn.execute(
-        """CREATE TABLE a (
-            id INTEGER, date TEXT, name TEXT,
-            distance_m REAL, moving_time_s INTEGER,
-            avg_pace_s_per_km REAL, avg_hr REAL, max_hr INTEGER,
-            avg_cadence REAL, elevation_gain_m REAL,
-            suffer_score INTEGER, perceived_exertion REAL,
-            sport_type TEXT
-        )"""
-    )
-    conn.execute(
-        "INSERT INTO a VALUES (1,'2025-06-15','Morning Run',10000,3600,360,145,165,174,50,42,5,'Run')"
-    )
-    row = conn.execute("SELECT * FROM a").fetchone()
-    yield row
-    conn.close()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -88,6 +88,7 @@ def test_claude_stream_turn_appends_history(mock_anthropic):
 
 
 def test_claude_stream_turn_initial_history_preserved(mock_anthropic):
+    """Prior history must survive a stream_turn call — not get clobbered."""
     mock_anthropic.return_value.messages.stream.return_value = _claude_stream(["ok"])
 
     from strides_ai.backends.claude import ClaudeBackend
@@ -97,6 +98,8 @@ def test_claude_stream_turn_initial_history_preserved(mock_anthropic):
         {"role": "assistant", "content": "prev a"},
     ]
     b = ClaudeBackend("key", prior)
+    b.stream_turn("sys", "new q", lambda _: None)
+
     assert b._history[0]["content"] == "prev q"
     assert b._history[1]["content"] == "prev a"
 
@@ -368,6 +371,7 @@ def test_openai_stream_turn_appends_history(mock_openai):
 
 
 def test_openai_stream_turn_initial_history_preserved(mock_openai):
+    """Prior history must survive a stream_turn call — not get clobbered."""
     mock_openai.return_value.chat.completions.create.return_value = _oai_stream([_oai_chunk("ok")])
 
     from strides_ai.backends.openai import OpenAIBackend
@@ -377,6 +381,8 @@ def test_openai_stream_turn_initial_history_preserved(mock_openai):
         {"role": "assistant", "content": "prev a"},
     ]
     b = OpenAIBackend("key", prior)
+    b.stream_turn("sys", "new q", lambda _: None)
+
     assert b._history[0]["content"] == "prev q"
     assert b._history[1]["content"] == "prev a"
 
@@ -609,6 +615,7 @@ def test_ollama_retries_without_tools_on_400(mocker):
 
 
 def test_ollama_stream_turn_initial_history_preserved(mocker):
+    """Prior history must survive a stream_turn call — not get clobbered."""
     _ollama_http_client(mocker, [_ollama_chunk("ok", done=True)])
 
     from strides_ai.backends.ollama import OllamaBackend
@@ -618,5 +625,7 @@ def test_ollama_stream_turn_initial_history_preserved(mocker):
         {"role": "assistant", "content": "prev a"},
     ]
     b = OllamaBackend("llama3.1", prior)
+    b.stream_turn("sys", "new q", lambda _: None)
+
     assert b._history[0]["content"] == "prev q"
     assert b._history[1]["content"] == "prev a"

--- a/tests/test_charts_data.py
+++ b/tests/test_charts_data.py
@@ -1,6 +1,5 @@
 """Unit tests for strides_ai.charts_data — all pure functions."""
 
-import math
 from datetime import date, timedelta
 
 import pytest
@@ -180,13 +179,6 @@ def test_atl_ctl_ratio_none_when_ctl_negligible():
         assert first["ratio"] is None
     else:
         assert first["ratio"] is not None
-
-
-def test_atl_ctl_ctl_smoother_than_atl():
-    """CTL (42-day EWA) should respond more slowly than ATL (7-day EWA)."""
-    alpha_atl = 1 - math.exp(-1 / 7)
-    alpha_ctl = 1 - math.exp(-1 / 42)
-    assert alpha_atl > alpha_ctl
 
 
 # ── compute_aerobic_efficiency ────────────────────────────────────────────────

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -382,11 +382,3 @@ def test_get_recent_messages_includes_model_field(tmp_db):
     db.save_message("assistant", "reply", model="gemini:gemini-2.0-flash")
     msg = db.get_recent_messages(1)[0]
     assert "model" in msg
-
-
-def test_save_message_model_is_none_when_not_provided(tmp_db):
-    """Messages saved without a model label default to None."""
-    db.save_message("assistant", "old message", mode="running")
-    msgs = db.get_recent_messages(10)
-    old = next(m for m in msgs if m["content"] == "old message")
-    assert old["model"] is None

--- a/tests/test_hevy.py
+++ b/tests/test_hevy.py
@@ -18,7 +18,7 @@ def test_estimate_1rm_basic():
 
 
 def test_estimate_1rm_single_rep():
-    # 1 rep = the weight itself (approximately)
+    # 1 rep: 140 * (1 + 1/30) ≈ 144.7
     result = estimate_1rm(140.0, 1)
     assert result == pytest.approx(140.0 * (1 + 1 / 30), abs=0.1)
 
@@ -119,9 +119,8 @@ _SAMPLE_WORKOUT = {
 }
 
 
-def test_transform_workout_sport_type():
+def test_transform_workout_exercises_json():
     row = _transform_workout(_SAMPLE_WORKOUT)
-    # sport_type is set in upsert_hevy, not transform — check exercises_json present
     assert row["exercises_json"] is not None
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -59,6 +59,20 @@ def test_get_default_fields_returns_deep_copy():
     assert f2["personal"]["name"] == ""
 
 
+def test_get_default_fields_lifting_keys():
+    fields = get_default_fields("lifting")
+    assert set(fields.keys()) == {
+        "personal",
+        "lifting_background",
+        "lifting_bests",
+        "goals",
+        "injuries_and_health",
+        "equipment",
+        "nutrition_snacks",
+        "other_notes",
+    }
+
+
 def test_get_default_fields_unknown_mode_falls_back_to_running():
     fields = get_default_fields("triathlon")
     assert "running_background" in fields
@@ -128,3 +142,12 @@ def test_profile_to_text_nutrition_snacks_appear():
     result = profile_to_text(fields, "running")
     assert "banana" in result
     assert "gel" in result
+
+
+def test_profile_to_text_lifting_fields():
+    fields = get_default_fields("lifting")
+    fields["lifting_bests"]["squat_1rm"] = "140 kg"
+    fields["lifting_bests"]["bench_press_1rm"] = "100 kg"
+    result = profile_to_text(fields, "lifting")
+    assert "140 kg" in result
+    assert "100 kg" in result


### PR DESCRIPTION
## Summary
- Removed unused `activity_row` fixture from `conftest.py` (never referenced in any test)
- Removed `test_atl_ctl_ctl_smoother_than_atl` — only checked a math identity, never called production code; wouldn't catch constant changes in `charts_data.py`
- Removed duplicate `test_save_message_model_is_none_when_not_provided` (identical assertion already covered by `test_save_message_model_defaults_to_none`)
- Renamed `test_transform_workout_sport_type` → `test_transform_workout_exercises_json` (the test was never checking `sport_type`)
- Fixed misleading comment in `test_estimate_1rm_single_rep` ("1 rep = the weight itself" is wrong; the Epley formula gives `weight * (1 + 1/30)`)
- Made the three `*_initial_history_preserved` backend tests (Claude, OpenAI, Ollama) actually call `stream_turn` — they previously only checked the constructor, so a regression that clobbered prior history during a turn would have gone undetected
- Added `test_get_default_fields_lifting_keys` and `test_profile_to_text_lifting_fields` to cover the `lifting` mode that was added to `profile.py` without any tests

## Test plan
- [ ] `make test` passes (291 tests, pre-commit hook verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)