### PR TITLE
feat(settings): system-wide metric ↔ imperial units toggle

### DIFF
--- a/strides_ai/analysis.py
+++ b/strides_ai/analysis.py
@@ -364,19 +364,27 @@ def build_analysis_summary(metrics: dict) -> str:
             zone_msg = f"Dominant effort Z{dominant[0]} ({dominant[1]:.0f}%)"
         parts.append(zone_msg + ".")
 
-    # Pace fade
+    # Pace fade — emit both unit forms inline so the analysis text reads correctly
+    # whichever units preference is active when the activity is later viewed.
     pf = metrics.get("pace_fade_seconds")
     if pf is not None and abs(pf) > 15:
+        pf_km = pf / 1.60934
         if pf > 0:
-            parts.append(f"Positive pace fade of {pf:.0f}s/mile in final third.")
+            parts.append(f"Positive pace fade of {pf:.0f}s/mi ({pf_km:.0f}s/km) in final third.")
         else:
-            parts.append(f"Negative split — improved {abs(pf):.0f}s/mile in final third.")
+            parts.append(
+                f"Negative split — improved {abs(pf):.0f}s/mi ({abs(pf_km):.0f}s/km) in final third."
+            )
 
-    # Elevation
+    # Elevation — bilingual: ft/mi (stored) and m/km (derived)
     if metrics.get("high_elevation_flag"):
         elev = metrics.get("elevation_per_mile")
         if elev is not None:
-            parts.append(f"Hilly course ({elev:.0f} ft/mile elevation gain).")
+            # ft/mi → m/km: ft × 0.3048 / mile (1.60934 km) = m/km
+            elev_m_per_km = elev * 0.3048 / 1.60934
+            parts.append(
+                f"Hilly course ({elev:.0f} ft/mi · {elev_m_per_km:.0f} m/km elevation gain)."
+            )
 
     # Suffer score mismatch
     if metrics.get("suffer_score_mismatch_flag"):

--- a/strides_ai/api/app.py
+++ b/strides_ai/api/app.py
@@ -31,7 +31,8 @@ async def lifespan(app: FastAPI):
     UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
     saved_mode = db.get_setting("mode", "running")
     saved_provider = db.get_setting("provider", get_settings().provider)
-    init_backend(app, mode=saved_mode, provider=saved_provider)
+    saved_units = db.get_setting("units", "metric")
+    init_backend(app, mode=saved_mode, provider=saved_provider, units=saved_units)
     yield
 
 

--- a/strides_ai/api/deps.py
+++ b/strides_ai/api/deps.py
@@ -86,19 +86,29 @@ def provider_statuses() -> list[dict]:
     ]
 
 
-def init_backend(app: FastAPI, mode: str | None = None, provider: str | None = None) -> None:
-    """Called at server startup (and on mode/profile/provider changes) to build the LLM backend."""
+def init_backend(
+    app: FastAPI,
+    mode: str | None = None,
+    provider: str | None = None,
+    units: str | None = None,
+) -> None:
+    """Called at server startup (and on mode/provider/units changes) to build the LLM backend."""
     if mode is not None:
         app.state.mode = mode
     if provider is not None:
         app.state.provider = provider
+    if units is not None:
+        app.state.units = units
     current_mode = getattr(app.state, "mode", "running")
+    current_units = getattr(app.state, "units", None) or db.get_setting("units", "metric")
     settings = get_settings()
     current_provider = (getattr(app.state, "provider", None) or settings.provider).lower()
 
     activities = db.get_activities_for_mode(current_mode)
     prior_messages = db.get_recent_messages(RECALL_MESSAGES, mode=current_mode)
-    initial_history = build_initial_history(activities, prior_messages, mode=current_mode)
+    initial_history = build_initial_history(
+        activities, prior_messages, mode=current_mode, units=current_units
+    )
 
     if current_provider == "ollama":
         available = get_provider_models("ollama")

--- a/strides_ai/api/routers/charts.py
+++ b/strides_ai/api/routers/charts.py
@@ -1,6 +1,6 @@
 """Charts route."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
 from ...charts_data import get_chart_data as get_cardio_chart_data
@@ -8,6 +8,7 @@ from ...charts_lifting import get_chart_data as get_lifting_chart_data
 from ...config import VALID_MODES
 from ...db import activities as crud
 from ...db import exercise_templates as tmpl_crud
+from ...db import settings as settings_crud
 from ...db.engine import get_session
 
 router = APIRouter()
@@ -15,16 +16,21 @@ router = APIRouter()
 
 @router.get("/charts")
 def charts(
-    unit: str = "miles",
     mode: str = "running",
     session: Session = Depends(get_session),
 ):
-    if unit not in ("miles", "km"):
-        raise HTTPException(status_code=400, detail="unit must be 'miles' or 'km'")
+    """Return chart data for the requested mode in the user's preferred units.
+
+    The legacy ``?unit=miles|km`` query parameter is no longer honoured —
+    units are read from the global ``units`` setting (``metric`` | ``imperial``).
+    """
     if mode not in VALID_MODES:
         mode = "running"
+    units = settings_crud.get(session, "units", "metric") or "metric"
     rows = [r.model_dump() for r in crud.get_for_mode(session, mode)]
     if mode == "lifting":
         muscle_map = tmpl_crud.get_muscle_map(session)
-        return get_lifting_chart_data(rows, template_muscle_map=muscle_map)
-    return get_cardio_chart_data(rows, unit)
+        return get_lifting_chart_data(rows, template_muscle_map=muscle_map, units=units)
+    # charts_data.py internally speaks "miles"|"km"; translate.
+    cardio_unit = "miles" if units == "imperial" else "km"
+    return get_cardio_chart_data(rows, cardio_unit)

--- a/strides_ai/api/routers/chat.py
+++ b/strides_ai/api/routers/chat.py
@@ -19,6 +19,7 @@ from ...db import activities as act_crud
 from ...db import conversations as conv_crud
 from ...db import memories as mem_crud
 from ...db import profiles as prof_crud
+from ...db import settings as settings_crud
 from ...db.engine import get_engine, get_session
 from ...profile import profile_to_text
 from ..deps import get_backend
@@ -90,12 +91,14 @@ async def chat(
     profile = profile_to_text(profile_fields, mode)
     coach_voice = (profile_fields or {}).get("coach_voice", "")
     activities = [r.model_dump() for r in act_crud.get_for_mode(session, mode)]
+    units = settings_crud.get(session, "units", "metric") or "metric"
     system = build_system(
         profile,
         [r.model_dump() for r in memories],
         mode=mode,
         activities=activities,
         coach_voice=coach_voice,
+        units=units,
     )
 
     conv_crud.save(session, "user", saved_message, mode=mode)

--- a/strides_ai/api/routers/settings.py
+++ b/strides_ai/api/routers/settings.py
@@ -7,6 +7,7 @@ from sqlmodel import Session
 from ...config import VALID_MODES, VALID_PROVIDERS, get_settings
 from ...db import settings as crud
 from ...db.engine import get_session
+from ...units import VALID_UNITS
 from ..deps import get_provider_models, provider_statuses, init_backend
 
 router = APIRouter()
@@ -16,6 +17,7 @@ class SettingsBody(BaseModel):
     mode: str | None = None
     provider: str | None = None
     model: str | None = None
+    units: str | None = None
 
 
 @router.get("/settings")
@@ -23,6 +25,7 @@ def get_api_settings(session: Session = Depends(get_session)):
     return {
         "mode": crud.get(session, "mode", "running"),
         "provider": crud.get(session, "provider", get_settings().provider),
+        "units": crud.get(session, "units", "metric"),
     }
 
 
@@ -48,11 +51,23 @@ def put_settings(
     if body.model is not None:
         target = body.provider or crud.get(session, "provider", settings.provider) or "claude"
         crud.set(session, f"{target}_model", body.model)
-    if body.mode is not None or body.provider is not None or body.model is not None:
-        init_backend(request.app, mode=body.mode, provider=body.provider)
+    if body.units is not None:
+        if body.units not in VALID_UNITS:
+            raise HTTPException(
+                status_code=400, detail=f"units must be one of {sorted(VALID_UNITS)}"
+            )
+        crud.set(session, "units", body.units)
+    if (
+        body.mode is not None
+        or body.provider is not None
+        or body.model is not None
+        or body.units is not None
+    ):
+        init_backend(request.app, mode=body.mode, provider=body.provider, units=body.units)
     return {
         "mode": crud.get(session, "mode", "running"),
         "provider": crud.get(session, "provider", settings.provider),
+        "units": crud.get(session, "units", "metric"),
     }
 
 

--- a/strides_ai/charts_lifting.py
+++ b/strides_ai/charts_lifting.py
@@ -23,6 +23,7 @@ from datetime import date, timedelta
 from typing import Iterator
 
 from .hevy_analysis import estimate_1rm
+from .units import KG_TO_LB
 
 log = logging.getLogger(__name__)
 
@@ -112,13 +113,19 @@ def _rolling_avg(values: list[float], window: int = 4) -> list[float]:
 # ── Weekly volume ─────────────────────────────────────────────────────────────
 
 
-def compute_weekly_volume(activities: list[dict]) -> list[dict]:
-    """Sum total_volume_kg per ISO week with 4-week trailing rolling average."""
+def compute_weekly_volume(activities: list[dict], units: str = "metric") -> list[dict]:
+    """Sum total_volume_kg per ISO week with 4-week trailing rolling average.
+
+    Values are converted to lbs when ``units == "imperial"``.
+    """
+    factor = KG_TO_LB if units == "imperial" else 1.0
     weekly: dict[date, float] = defaultdict(float)
     for act in activities:
         if not act.get("date") or not act.get("total_volume_kg"):
             continue
-        weekly[_week_start(date.fromisoformat(act["date"]))] += float(act["total_volume_kg"])
+        weekly[_week_start(date.fromisoformat(act["date"]))] += (
+            float(act["total_volume_kg"]) * factor
+        )
 
     if not weekly:
         return []
@@ -174,15 +181,20 @@ def compute_weekly_sessions(activities: list[dict]) -> list[dict]:
 # ── 1RM progression ───────────────────────────────────────────────────────────
 
 
-def compute_one_rm_progression(activities: list[dict], top_n: int = 6) -> dict:
+def compute_one_rm_progression(
+    activities: list[dict], top_n: int = 6, units: str = "metric"
+) -> dict:
     """Per-exercise estimated 1RM time series.
 
     Returns ``{"series": {exercise_title: [{date, one_rm_kg}, ...]}, "exercises": [titles]}``.
+    The point key stays ``one_rm_kg`` for backward compatibility with the existing
+    test suite; values are converted to lbs when ``units == "imperial"``.
 
     ``top_n`` keeps the exercises with the most working sets across the dataset
     so the chart auto-surfaces the lifts the athlete actually trains. Sets with
     reps > 12 are dropped by ``estimate_1rm``.
     """
+    factor = KG_TO_LB if units == "imperial" else 1.0
     set_counts: Counter[str] = Counter()
     daily_max: dict[str, dict[date, float]] = defaultdict(dict)
 
@@ -209,7 +221,7 @@ def compute_one_rm_progression(activities: list[dict], top_n: int = 6) -> dict:
     series: dict[str, list[dict]] = {}
     for title in top_titles:
         points = [
-            {"date": d.isoformat(), "one_rm_kg": round(v, 1)}
+            {"date": d.isoformat(), "one_rm_kg": round(v * factor, 1)}
             for d, v in sorted(daily_max[title].items())
         ]
         if points:
@@ -306,12 +318,14 @@ def compute_rpe_trend(activities: list[dict]) -> list[dict]:
 def get_chart_data(
     activities: list[dict],
     template_muscle_map: dict[str, str] | None = None,
+    units: str = "metric",
 ) -> dict:
     acts = [dict(a) for a in activities]
     return {
-        "weekly_volume": compute_weekly_volume(acts),
+        "units": units,
+        "weekly_volume": compute_weekly_volume(acts, units),
         "weekly_sessions": compute_weekly_sessions(acts),
-        "one_rm_progression": compute_one_rm_progression(acts),
+        "one_rm_progression": compute_one_rm_progression(acts, units=units),
         "muscle_group_sets": compute_muscle_group_sets_per_week(acts, template_muscle_map),
         "rpe_trend": compute_rpe_trend(acts),
     }

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from . import db
 from .modes import MODES
+from .units import dist_unit_label, llm_unit_instruction, km_to_distance
 
 RECALL_MESSAGES = 40
 # Number of most-recent activities always pinned in the system prompt each turn.
@@ -58,9 +59,13 @@ def build_system(
     mode: str = "running",
     activities: list | None = None,
     coach_voice: str = "",
+    units: str = "metric",
 ) -> str:
     cfg = MODES.get(mode, MODES["running"])
     prompt = cfg.system_prompt
+
+    # Inject the unit instruction dynamically based on the athlete's preference.
+    prompt += f"\n\n{llm_unit_instruction(mode, units)}"
 
     voice_block = VOICE_INSTRUCTIONS.get(coach_voice, "")
     if not voice_block and coach_voice:
@@ -88,14 +93,19 @@ def build_system(
 
     upcoming = db.get_upcoming_planned_workouts()
     if upcoming:
-        header = "Date       | Type             | Distance | Duration | Intensity"
-        sep = "-" * 65
+        dist_label = dist_unit_label(units)
+        header = f"Date       | Type             | Distance     | Duration | Intensity"
+        sep = "-" * 70
         rows = []
         for w in upcoming:
-            dist = f"{w['distance_km']} km" if w.get("distance_km") else "—"
+            if w.get("distance_km"):
+                dist_value = km_to_distance(w["distance_km"], units)
+                dist = f"{dist_value:.2f} {dist_label}" if dist_value is not None else "—"
+            else:
+                dist = "—"
             dur = f"{w['duration_min']} min" if w.get("duration_min") else "—"
             rows.append(
-                f"{w['date']:10s} | {(w['workout_type'] or '')[:16]:16s} | {dist:8s} | {dur:8s} | {w.get('intensity') or '—'}"
+                f"{w['date']:10s} | {(w['workout_type'] or '')[:16]:16s} | {dist:12s} | {dur:8s} | {w.get('intensity') or '—'}"
             )
         prompt += (
             "\n\n## Upcoming Planned Workouts (next 14 days)\n"
@@ -111,6 +121,7 @@ def build_system(
     recent = (activities or [])[:RECENT_ACTIVITIES_IN_SYSTEM]
 
     if cfg.has_analysis and any(a.get("analysis_summary") for a in recent):
+        pace_fade_unit = "sec/mi" if units == "imperial" else "sec/km"
         prompt += (
             "\n\n## Analysis Metrics Guide\n"
             "The ANALYSIS column in the training log contains auto-generated summaries. "
@@ -121,11 +132,11 @@ def build_system(
             "higher = more efficient pace for a given HR\n"
             "- **HR zones**: Z1=recovery, Z2=aerobic base, Z3=tempo, "
             "Z4=threshold, Z5=VO2max/max effort\n"
-            "- **Pace fade**: sec/mile change in final third vs first third; "
+            f"- **Pace fade**: {pace_fade_unit} change in final third vs first third; "
             "positive = slowing (possible fatigue), negative = negative split"
         )
 
-    recent_log = build_training_log(recent, mode)
+    recent_log = build_training_log(recent, mode, units)
     prompt += (
         f"\n\n## Recent Activities (last {RECENT_ACTIVITIES_IN_SYSTEM})\n\n```\n{recent_log}\n```"
     )
@@ -133,21 +144,26 @@ def build_system(
     return prompt
 
 
-def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
+def build_training_log(
+    rows: list[sqlite3.Row], mode: str = "running", units: str = "metric"
+) -> str:
     if not rows:
         return "No activities found."
     cfg = MODES.get(mode, MODES["running"])
     sep = "-" * cfg.log_sep_len
-    lines = [cfg.log_header, sep]
+    lines = [cfg.log_header(units), sep]
     for r in reversed(rows):
-        lines.append(cfg.format_log_row(r))
+        lines.append(cfg.format_log_row(r, units))
     lines.append(sep)
-    lines.append(cfg.format_log_total(rows))
+    lines.append(cfg.format_log_total(rows, units))
     return "\n".join(lines)
 
 
 def build_initial_history(
-    activities: list, prior_messages: list[dict], mode: str = "running"
+    activities: list,
+    prior_messages: list[dict],
+    mode: str = "running",
+    units: str = "metric",
 ) -> list[dict]:
     """
     Seed the backend's conversation history with the full training log (once)
@@ -159,7 +175,7 @@ def build_initial_history(
     only the oldest runs are dropped — recent ones are protected by the system prompt.
     """
     cfg = MODES.get(mode, MODES["running"])
-    training_log = build_training_log(activities, mode)
+    training_log = build_training_log(activities, mode, units)
     log_message = f"Here is the athlete's complete training log:\n\n```\n{training_log}\n```"
     return [
         {"role": "user", "content": log_message},

--- a/strides_ai/modes.py
+++ b/strides_ai/modes.py
@@ -16,6 +16,18 @@ from dataclasses import dataclass
 from typing import Callable
 
 from .db.models import CYCLE_TYPES, LIFT_TYPES, RUN_TYPES
+from .units import (
+    dist_unit_label,
+    elev_unit_label,
+    kg_to_weight,
+    m_to_distance,
+    m_to_elevation,
+    pace_unit_label,
+    s_per_km_to_pace_seconds,
+    s_per_km_to_speed,
+    speed_unit_label,
+    weight_unit_label,
+)
 
 # ── System prompts ─────────────────────────────────────────────────────────────
 
@@ -29,7 +41,6 @@ complete Strava training log. Your role is to:
 injury prevention, and periodisation.
 - Be concise but thorough. When referencing specific runs, cite the date and \
 key metrics (distance, pace, HR).
-- Use metric units (km, min/km) unless the athlete asks otherwise.
 - When advising on nutrition for a run, suggest a concrete sample loadout \
 (e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
 preferred snacks in their profile, choose from those; otherwise use sensible \
@@ -53,7 +64,6 @@ complete Strava training log. Your role is to:
 injury prevention, and periodisation for cyclists.
 - Be concise but thorough. When referencing specific rides, cite the date and \
 key metrics (distance, speed, HR).
-- Use metric units (km, km/h) unless the athlete asks otherwise.
 - When advising on nutrition for a ride, suggest a concrete sample loadout \
 (e.g. "2 gels, 1 energy bar, 750 ml electrolytes"). If the athlete has listed \
 preferred snacks in their profile, choose from those; otherwise use sensible \
@@ -77,7 +87,6 @@ complete Strava training log covering both running and cycling. Your role is to:
 pacing, recovery, race preparation, injury prevention, and periodisation.
 - Be concise but thorough. When referencing specific activities, cite the date, \
 sport type, and key metrics.
-- Use metric units unless the athlete asks otherwise.
 - When advising on nutrition for any activity, suggest a concrete sample loadout \
 (e.g. "2 gels, 1 granola bar, 500 ml electrolytes"). If the athlete has listed \
 preferred snacks in their profile, choose from those; otherwise use sensible \
@@ -101,7 +110,6 @@ complete HEVY training log. Your role is to:
 injury prevention, deload timing, and exercise selection.
 - Be concise but thorough. When referencing specific sessions, cite the date and \
 key metrics (exercises, volume, RPE, estimated 1RM).
-- Use metric units (kg) unless the athlete asks otherwise.
 - When estimating 1-rep maxes, use the Epley formula (weight × (1 + reps/30)) and \
 note it is an estimate.
 
@@ -117,19 +125,20 @@ persist across sessions.\
 # ── Training log format helpers ────────────────────────────────────────────────
 
 
-def _format_pace(s_per_km: float | None) -> str:
-    if s_per_km is None:
+def _format_pace(s_per_km: float | None, units: str = "metric") -> str:
+    s = s_per_km_to_pace_seconds(s_per_km, units)
+    if s is None:
         return "—"
-    mins = int(s_per_km // 60)
-    secs = int(s_per_km % 60)
-    return f"{mins}:{secs:02d}/km"
+    mins = int(s // 60)
+    secs = int(s % 60)
+    return f"{mins}:{secs:02d}/{dist_unit_label(units)}"
 
 
-def _format_speed(s_per_km: float | None) -> str:
-    if s_per_km is None or s_per_km <= 0:
+def _format_speed(s_per_km: float | None, units: str = "metric") -> str:
+    v = s_per_km_to_speed(s_per_km, units)
+    if v is None:
         return "—"
-    kph = 3600 / s_per_km
-    return f"{kph:.1f}km/h"
+    return f"{v:.1f}{speed_unit_label(units)}"
 
 
 def _format_duration(seconds: int | None) -> str:
@@ -142,96 +151,151 @@ def _format_duration(seconds: int | None) -> str:
     return f"{m}m{s:02d}s"
 
 
+def _format_distance(distance_m: float | None, units: str) -> str:
+    v = m_to_distance(distance_m, units)
+    return f"{v:8.2f}" if v is not None else "    —   "
+
+
+def _format_elevation(elevation_m: float | None, units: str) -> str:
+    v = m_to_elevation(elevation_m, units)
+    if v is None:
+        return "—"
+    return f"{v:.0f}"
+
+
+def _format_volume(volume_kg: float | None, units: str) -> str:
+    v = kg_to_weight(volume_kg, units)
+    if v is None:
+        return "—"
+    return f"{v:.0f}"
+
+
 # ── Per-mode log row formatters ────────────────────────────────────────────────
 
 
-def _running_log_row(r: dict) -> str:
-    dist_km = (r["distance_m"] or 0) / 1000
+def _running_log_row(r: dict, units: str = "metric") -> str:
     analysis = (r.get("analysis_summary") or "")[:60]
     return (
         f"{r['date'] or '?':10s} | "
         f"{(r['name'] or '')[:30]:30s} | "
-        f"{dist_km:8.2f} | "
+        f"{_format_distance(r['distance_m'], units):8s} | "
         f"{_format_duration(r['moving_time_s']):8s} | "
-        f"{_format_pace(r['avg_pace_s_per_km']):8s} | "
+        f"{_format_pace(r['avg_pace_s_per_km'], units):8s} | "
         f"{r['avg_hr'] or '—':6} | "
         f"{r['max_hr'] or '—':6} | "
         f"{r['avg_cadence'] or '—':12} | "
-        f"{r['elevation_gain_m'] or '—':7} | "
+        f"{_format_elevation(r['elevation_gain_m'], units):7} | "
         f"{r['suffer_score'] or '—':6} | "
         f"{r['perceived_exertion'] or '—':3} | "
         f"{analysis}"
     )
 
 
-def _cycling_log_row(r: dict) -> str:
-    dist_km = (r["distance_m"] or 0) / 1000
+def _cycling_log_row(r: dict, units: str = "metric") -> str:
     analysis = (r.get("analysis_summary") or "")[:60]
     return (
         f"{r['date'] or '?':10s} | "
         f"{(r['name'] or '')[:30]:30s} | "
-        f"{dist_km:8.2f} | "
+        f"{_format_distance(r['distance_m'], units):8s} | "
         f"{_format_duration(r['moving_time_s']):8s} | "
-        f"{_format_speed(r['avg_pace_s_per_km']):8s} | "
+        f"{_format_speed(r['avg_pace_s_per_km'], units):8s} | "
         f"{r['avg_hr'] or '—':6} | "
         f"{r['max_hr'] or '—':6} | "
         f"{r['avg_cadence'] or '—':12} | "
-        f"{r['elevation_gain_m'] or '—':7} | "
+        f"{_format_elevation(r['elevation_gain_m'], units):7} | "
         f"{r['suffer_score'] or '—':6} | "
         f"{r['perceived_exertion'] or '—':3} | "
         f"{analysis}"
     )
 
 
-def _hybrid_log_row(r: dict) -> str:
-    dist_km = (r["distance_m"] or 0) / 1000
+def _hybrid_log_row(r: dict, units: str = "metric") -> str:
     sport = r["sport_type"] or ""
     is_run = sport in RUN_TYPES
     pace_speed = (
-        _format_pace(r["avg_pace_s_per_km"]) if is_run else _format_speed(r["avg_pace_s_per_km"])
+        _format_pace(r["avg_pace_s_per_km"], units)
+        if is_run
+        else _format_speed(r["avg_pace_s_per_km"], units)
     )
     analysis = (r.get("analysis_summary") or "")[:60]
     return (
         f"{r['date'] or '?':10s} | "
         f"{sport[:10]:10s} | "
         f"{(r['name'] or '')[:30]:30s} | "
-        f"{dist_km:8.2f} | "
+        f"{_format_distance(r['distance_m'], units):8s} | "
         f"{_format_duration(r['moving_time_s']):8s} | "
         f"{pace_speed:11s} | "
         f"{r['avg_hr'] or '—':6} | "
         f"{r['max_hr'] or '—':6} | "
         f"{r['avg_cadence'] or '—':7} | "
-        f"{r['elevation_gain_m'] or '—':7} | "
+        f"{_format_elevation(r['elevation_gain_m'], units):7} | "
         f"{r['suffer_score'] or '—':6} | "
         f"{r['perceived_exertion'] or '—':3} | "
         f"{analysis}"
     )
 
 
-def _lifting_log_row(r: dict) -> str:
+def _lifting_log_row(r: dict, units: str = "metric") -> str:
     analysis = (r.get("analysis_summary") or "")[:60]
     return (
         f"{r['date'] or '?':10s} | "
         f"{(r['name'] or '')[:30]:30s} | "
         f"{_format_duration(r['moving_time_s']):8s} | "
         f"{r['total_sets'] or '—':4} | "
-        f"{r['total_volume_kg'] or '—':10} | "
+        f"{_format_volume(r['total_volume_kg'], units):10} | "
         f"{r['perceived_exertion'] or '—':3} | "
         f"{analysis}"
     )
 
 
-def _make_cardio_total(label: str) -> Callable[[list[dict]], str]:
-    def total(rows: list[dict]) -> str:
-        total_km = sum((r["distance_m"] or 0) / 1000 for r in rows)
-        return f"Total: {len(rows)} {label}, {total_km:.1f} km"
+def _make_cardio_total(label: str) -> Callable[[list[dict], str], str]:
+    def total(rows: list[dict], units: str = "metric") -> str:
+        total_dist = sum(m_to_distance(r["distance_m"] or 0, units) or 0 for r in rows)
+        return f"Total: {len(rows)} {label}, {total_dist:.1f} {dist_unit_label(units)}"
 
     return total
 
 
-def _lifting_log_total(rows: list[dict]) -> str:
-    total_volume = sum((r["total_volume_kg"] or 0) for r in rows)
-    return f"Total: {len(rows)} sessions, {total_volume:.0f} kg cumulative volume"
+def _lifting_log_total(rows: list[dict], units: str = "metric") -> str:
+    total_volume = sum(kg_to_weight(r["total_volume_kg"] or 0, units) or 0 for r in rows)
+    return (
+        f"Total: {len(rows)} sessions, "
+        f"{total_volume:.0f} {weight_unit_label(units)} cumulative volume"
+    )
+
+
+# ── Per-mode log header builders ──────────────────────────────────────────────
+
+
+def _running_header(units: str = "metric") -> str:
+    return (
+        f"DATE       | NAME                           | DIST({dist_unit_label(units)})  | "
+        f"DURATION | PACE     | AVG HR | MAX HR | CADENCE(spm) | "
+        f"ELEV({elev_unit_label(units)}) | SUFFER | RPE | ANALYSIS"
+    )
+
+
+def _cycling_header(units: str = "metric") -> str:
+    return (
+        f"DATE       | NAME                           | DIST({dist_unit_label(units)})  | "
+        f"DURATION | SPEED    | AVG HR | MAX HR | CADENCE(rpm) | "
+        f"ELEV({elev_unit_label(units)}) | SUFFER | RPE | ANALYSIS"
+    )
+
+
+def _hybrid_header(units: str = "metric") -> str:
+    return (
+        f"DATE       | TYPE       | NAME                           | DIST({dist_unit_label(units)})  | "
+        f"DURATION | PACE/SPEED  | AVG HR | MAX HR | CADENCE | "
+        f"ELEV({elev_unit_label(units)}) | SUFFER | RPE | ANALYSIS"
+    )
+
+
+def _lifting_header(units: str = "metric") -> str:
+    return (
+        f"DATE       | NAME                           | DURATION | SETS | "
+        f"VOLUME({weight_unit_label(units)}) | RPE | ANALYSIS"
+    )
 
 
 # ── ModeConfig ─────────────────────────────────────────────────────────────────
@@ -245,10 +309,10 @@ class ModeConfig:
     has_analysis: bool  # whether to inject the cardio metrics guide
     hidden_tabs: frozenset[str]  # frontend tabs to hide for this mode
     activity_label: str  # "runs", "rides", "sessions", "activities"
-    log_header: str  # column header row for training log
+    log_header: Callable[[str], str]  # column header row for training log; takes units
     log_sep_len: int  # length of the separator line
-    format_log_row: Callable[[dict], str]
-    format_log_total: Callable[[list[dict]], str]
+    format_log_row: Callable[[dict, str], str]  # row formatter; takes units
+    format_log_total: Callable[[list[dict], str], str]  # totals line; takes units
     profile_section_keys: list[str]  # ordered section keys for profile_to_text
 
 
@@ -260,10 +324,7 @@ MODES: dict[str, ModeConfig] = {
         has_analysis=True,
         hidden_tabs=frozenset(),
         activity_label="runs",
-        log_header=(
-            "DATE       | NAME                           | DIST(km) | DURATION | PACE     "
-            "| AVG HR | MAX HR | CADENCE(spm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
-        ),
+        log_header=_running_header,
         log_sep_len=200,
         format_log_row=_running_log_row,
         format_log_total=_make_cardio_total("runs"),
@@ -285,10 +346,7 @@ MODES: dict[str, ModeConfig] = {
         has_analysis=True,
         hidden_tabs=frozenset(),
         activity_label="rides",
-        log_header=(
-            "DATE       | NAME                           | DIST(km) | DURATION | SPEED    "
-            "| AVG HR | MAX HR | CADENCE(rpm) | ELEV(m) | SUFFER | RPE | ANALYSIS"
-        ),
+        log_header=_cycling_header,
         log_sep_len=200,
         format_log_row=_cycling_log_row,
         format_log_total=_make_cardio_total("rides"),
@@ -310,10 +368,7 @@ MODES: dict[str, ModeConfig] = {
         has_analysis=True,
         hidden_tabs=frozenset(),
         activity_label="activities",
-        log_header=(
-            "DATE       | TYPE       | NAME                           | DIST(km) | DURATION "
-            "| PACE/SPEED  | AVG HR | MAX HR | CADENCE | ELEV(m) | SUFFER | RPE | ANALYSIS"
-        ),
+        log_header=_hybrid_header,
         log_sep_len=215,
         format_log_row=_hybrid_log_row,
         format_log_total=_make_cardio_total("activities"),
@@ -337,9 +392,7 @@ MODES: dict[str, ModeConfig] = {
         has_analysis=False,
         hidden_tabs=frozenset({"calendar"}),
         activity_label="sessions",
-        log_header=(
-            "DATE       | NAME                           | DURATION | SETS | VOLUME(kg) | RPE | ANALYSIS"
-        ),
+        log_header=_lifting_header,
         log_sep_len=140,
         format_log_row=_lifting_log_row,
         format_log_total=_lifting_log_total,

--- a/strides_ai/units.py
+++ b/strides_ai/units.py
@@ -1,0 +1,199 @@
+"""Central unit conversion module.
+
+Single source of truth for the metric ↔ imperial display switch. All storage
+in the app stays canonical SI (metres, kilograms, seconds); these helpers run
+at the display layer and inside the LLM prompt builder.
+
+The frontend's ``web/src/units.ts`` mirrors this module 1:1.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+Units = Literal["metric", "imperial"]
+VALID_UNITS: frozenset[str] = frozenset({"metric", "imperial"})
+
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+M_TO_MI = 0.000621371
+M_TO_KM = 0.001
+KG_TO_LB = 2.20462
+M_TO_FT = 3.28084
+S_PER_KM_TO_S_PER_MI = 1.60934
+
+
+# ── Labels ────────────────────────────────────────────────────────────────────
+
+
+def dist_unit_label(units: str) -> str:
+    return "mi" if units == "imperial" else "km"
+
+
+def weight_unit_label(units: str) -> str:
+    return "lb" if units == "imperial" else "kg"
+
+
+def elev_unit_label(units: str) -> str:
+    return "ft" if units == "imperial" else "m"
+
+
+def speed_unit_label(units: str) -> str:
+    return "mph" if units == "imperial" else "km/h"
+
+
+def pace_unit_label(units: str) -> str:
+    return "min/mi" if units == "imperial" else "min/km"
+
+
+# ── Numeric conversions ───────────────────────────────────────────────────────
+
+
+def m_to_distance(m: float | None, units: str) -> float | None:
+    if m is None:
+        return None
+    return m * (M_TO_MI if units == "imperial" else M_TO_KM)
+
+
+def km_to_distance(km: float | None, units: str) -> float | None:
+    if km is None:
+        return None
+    return (km * 1000.0) * (M_TO_MI if units == "imperial" else M_TO_KM)
+
+
+def kg_to_weight(kg: float | None, units: str) -> float | None:
+    if kg is None:
+        return None
+    return kg * KG_TO_LB if units == "imperial" else kg
+
+
+def m_to_elevation(m: float | None, units: str) -> float | None:
+    if m is None:
+        return None
+    return m * M_TO_FT if units == "imperial" else m
+
+
+def s_per_km_to_pace_seconds(s_per_km: float | None, units: str) -> float | None:
+    """Convert seconds/km to seconds per the user's preferred distance unit."""
+    if s_per_km is None:
+        return None
+    return s_per_km * S_PER_KM_TO_S_PER_MI if units == "imperial" else s_per_km
+
+
+def s_per_km_to_speed(s_per_km: float | None, units: str) -> float | None:
+    """Convert seconds/km pace to speed in the user's preferred unit (km/h or mph)."""
+    if s_per_km is None or s_per_km <= 0:
+        return None
+    kph = 3600.0 / s_per_km
+    return kph * (M_TO_MI / M_TO_KM) if units == "imperial" else kph
+
+
+# ── Round-trip helpers (Calendar form input) ─────────────────────────────────
+
+
+def imperial_input_to_km(value: float | None, units: str) -> float | None:
+    """Take user input in their preferred unit and return km for storage."""
+    if value is None:
+        return None
+    if units == "imperial":
+        # value is in miles; convert to km
+        return value / (M_TO_MI / M_TO_KM)
+    return value
+
+
+def imperial_input_to_m(value: float | None, units: str) -> float | None:
+    """Take user input in their preferred elevation unit and return metres."""
+    if value is None:
+        return None
+    if units == "imperial":
+        return value / M_TO_FT
+    return value
+
+
+# ── Formatting helpers ────────────────────────────────────────────────────────
+
+
+def format_distance(m: float | None, units: str, *, precision: int = 2) -> str:
+    v = m_to_distance(m, units)
+    if v is None:
+        return "—"
+    return f"{v:.{precision}f}{dist_unit_label(units)}"
+
+
+def format_pace(s_per_km: float | None, units: str) -> str:
+    """Format pace as M:SS/<unit>. Imperial users see s per mile."""
+    s = s_per_km_to_pace_seconds(s_per_km, units)
+    if s is None:
+        return "—"
+    mins = int(s // 60)
+    secs = int(s % 60)
+    return f"{mins}:{secs:02d}/{dist_unit_label(units)}"
+
+
+def format_speed(s_per_km: float | None, units: str) -> str:
+    """Format speed as 'XX.X km/h' or 'XX.X mph'."""
+    v = s_per_km_to_speed(s_per_km, units)
+    if v is None:
+        return "—"
+    return f"{v:.1f}{speed_unit_label(units)}"
+
+
+def format_elevation(m: float | None, units: str, *, precision: int = 0) -> str:
+    v = m_to_elevation(m, units)
+    if v is None:
+        return "—"
+    return f"{v:.{precision}f}{elev_unit_label(units)}"
+
+
+def format_weight(kg: float | None, units: str, *, precision: int = 0) -> str:
+    v = kg_to_weight(kg, units)
+    if v is None:
+        return "—"
+    return f"{v:.{precision}f}{weight_unit_label(units)}"
+
+
+def format_duration(seconds: int | None) -> str:
+    """Unit-agnostic; kept here so callers have one place to import all formatters."""
+    if seconds is None:
+        return "—"
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h{m:02d}m{s:02d}s"
+    return f"{m}m{s:02d}s"
+
+
+# ── LLM unit instruction ──────────────────────────────────────────────────────
+
+
+def llm_unit_instruction(mode: str, units: str) -> str:
+    """Return the per-mode unit instruction line injected into the system prompt.
+
+    Replaces the hardcoded ``"Use metric units (km, min/km)…"`` line that used
+    to live in each mode's base prompt.
+    """
+    if units == "imperial":
+        if mode == "running":
+            return "Use imperial units (mi, min/mi) when reporting distances and paces."
+        if mode == "cycling":
+            return "Use imperial units (mi, mph) when reporting distances and speeds."
+        if mode == "lifting":
+            return (
+                "Use imperial units (lb) when reporting weights, sets, and 1RM estimates. "
+                "When estimating 1-rep maxes, still use the Epley formula (weight × (1 + reps/30))."
+            )
+        # hybrid / default
+        return "Use imperial units (mi, min/mi for runs, mph for rides) when reporting metrics."
+
+    # metric
+    if mode == "running":
+        return "Use metric units (km, min/km) when reporting distances and paces."
+    if mode == "cycling":
+        return "Use metric units (km, km/h) when reporting distances and speeds."
+    if mode == "lifting":
+        return (
+            "Use metric units (kg) when reporting weights, sets, and 1RM estimates. "
+            "When estimating 1-rep maxes, still use the Epley formula (weight × (1 + reps/30))."
+        )
+    return "Use metric units (km, min/km for runs, km/h for rides) when reporting metrics."

--- a/tests/test_charts_lifting.py
+++ b/tests/test_charts_lifting.py
@@ -438,13 +438,13 @@ def test_rpe_trend_sorts_by_date():
 
 def test_get_chart_data_returns_all_keys():
     out = get_chart_data([])
-    assert set(out.keys()) == {
+    assert {
         "weekly_volume",
         "weekly_sessions",
         "one_rm_progression",
         "muscle_group_sets",
         "rpe_trend",
-    }
+    }.issubset(out.keys())
 
 
 def test_get_chart_data_with_real_session():

--- a/tests/test_coach.py
+++ b/tests/test_coach.py
@@ -333,3 +333,74 @@ def test_build_training_log_hybrid_header_has_type_column():
     log = build_training_log([_make_row()], mode="hybrid")
     header = log.split("\n")[0]
     assert "TYPE" in header
+
+
+# ── Units-aware system prompt + log ───────────────────────────────────────────
+
+
+def test_build_system_running_metric_says_min_per_km(tmp_db):
+    result = build_system("", [], mode="running", units="metric")
+    assert "min/km" in result
+    assert "min/mi" not in result
+
+
+def test_build_system_running_imperial_says_min_per_mi(tmp_db):
+    result = build_system("", [], mode="running", units="imperial")
+    assert "min/mi" in result
+    assert "min/km" not in result
+
+
+def test_build_system_cycling_imperial_uses_mph(tmp_db):
+    result = build_system("", [], mode="cycling", units="imperial")
+    assert "mph" in result
+    assert "km/h" not in result
+
+
+def test_build_system_lifting_imperial_uses_lb(tmp_db):
+    result = build_system("", [], mode="lifting", units="imperial")
+    # Persona instruction line + log header row both reference lb
+    assert "lb" in result
+    # The bare token "kg" should not survive in imperial mode
+    # (we check the unit instruction phrase, not arbitrary substrings)
+    assert "Use imperial units (lb)" in result
+
+
+def test_build_system_lifting_metric_uses_kg(tmp_db):
+    result = build_system("", [], mode="lifting", units="metric")
+    assert "Use metric units (kg)" in result
+
+
+def test_build_training_log_imperial_header_swaps_dist_unit():
+    log = build_training_log([_make_row()], mode="running", units="imperial")
+    header = log.split("\n")[0]
+    assert "DIST(mi)" in header
+    assert "ELEV(ft)" in header
+
+
+def test_build_training_log_metric_header_uses_km_m():
+    log = build_training_log([_make_row()], mode="running", units="metric")
+    header = log.split("\n")[0]
+    assert "DIST(km)" in header
+    assert "ELEV(m)" in header
+
+
+def test_build_training_log_lifting_imperial_header():
+    row = {
+        "date": "2025-06-15",
+        "name": "Bench Day",
+        "moving_time_s": 3600,
+        "total_sets": 12,
+        "total_volume_kg": 1000.0,
+        "perceived_exertion": 8.0,
+        "analysis_summary": None,
+    }
+    log = build_training_log([row], mode="lifting", units="imperial")
+    header = log.split("\n")[0]
+    assert "VOLUME(lb)" in header
+
+
+def test_build_training_log_imperial_total_in_miles():
+    rows = [_make_row(distance_m=10_000), _make_row(distance_m=5_000)]
+    log = build_training_log(rows, mode="running", units="imperial")
+    # 15000 m → 9.32 mi (rounded to one decimal in totals = 9.3)
+    assert "9.3 mi" in log

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,267 @@
+"""Unit conversion module tests."""
+
+import pytest
+
+from strides_ai.units import (
+    KG_TO_LB,
+    M_TO_FT,
+    M_TO_MI,
+    S_PER_KM_TO_S_PER_MI,
+    VALID_UNITS,
+    dist_unit_label,
+    elev_unit_label,
+    format_distance,
+    format_elevation,
+    format_pace,
+    format_speed,
+    format_weight,
+    imperial_input_to_km,
+    imperial_input_to_m,
+    kg_to_weight,
+    km_to_distance,
+    llm_unit_instruction,
+    m_to_distance,
+    m_to_elevation,
+    pace_unit_label,
+    s_per_km_to_pace_seconds,
+    s_per_km_to_speed,
+    speed_unit_label,
+    weight_unit_label,
+)
+
+
+# ── Constants reference values ────────────────────────────────────────────────
+
+
+def test_constants_match_known_values():
+    # 1 km = 0.621371 mi
+    assert M_TO_MI == pytest.approx(0.000621371, rel=1e-6)
+    # 1 kg = 2.20462 lb
+    assert KG_TO_LB == pytest.approx(2.20462, rel=1e-5)
+    # 1 m = 3.28084 ft
+    assert M_TO_FT == pytest.approx(3.28084, rel=1e-5)
+    # 1 mile = 1.60934 km
+    assert S_PER_KM_TO_S_PER_MI == pytest.approx(1.60934, rel=1e-5)
+
+
+def test_valid_units_set():
+    assert VALID_UNITS == {"metric", "imperial"}
+
+
+# ── Labels ────────────────────────────────────────────────────────────────────
+
+
+def test_dist_unit_label():
+    assert dist_unit_label("metric") == "km"
+    assert dist_unit_label("imperial") == "mi"
+
+
+def test_weight_unit_label():
+    assert weight_unit_label("metric") == "kg"
+    assert weight_unit_label("imperial") == "lb"
+
+
+def test_elev_unit_label():
+    assert elev_unit_label("metric") == "m"
+    assert elev_unit_label("imperial") == "ft"
+
+
+def test_speed_unit_label():
+    assert speed_unit_label("metric") == "km/h"
+    assert speed_unit_label("imperial") == "mph"
+
+
+def test_pace_unit_label():
+    assert pace_unit_label("metric") == "min/km"
+    assert pace_unit_label("imperial") == "min/mi"
+
+
+# ── Numeric conversions ───────────────────────────────────────────────────────
+
+
+def test_m_to_distance_metric():
+    assert m_to_distance(5000, "metric") == pytest.approx(5.0)
+
+
+def test_m_to_distance_imperial():
+    # 5000 m = 3.10686 mi
+    assert m_to_distance(5000, "imperial") == pytest.approx(3.10686, rel=1e-4)
+
+
+def test_m_to_distance_none():
+    assert m_to_distance(None, "metric") is None
+
+
+def test_km_to_distance_metric_identity():
+    assert km_to_distance(10.0, "metric") == pytest.approx(10.0)
+
+
+def test_km_to_distance_imperial():
+    # 10 km = 6.21371 mi
+    assert km_to_distance(10.0, "imperial") == pytest.approx(6.21371, rel=1e-4)
+
+
+def test_kg_to_weight_metric_identity():
+    assert kg_to_weight(100.0, "metric") == pytest.approx(100.0)
+
+
+def test_kg_to_weight_imperial():
+    assert kg_to_weight(100.0, "imperial") == pytest.approx(220.462, rel=1e-4)
+
+
+def test_kg_to_weight_none():
+    assert kg_to_weight(None, "metric") is None
+
+
+def test_m_to_elevation_metric_identity():
+    assert m_to_elevation(1000.0, "metric") == pytest.approx(1000.0)
+
+
+def test_m_to_elevation_imperial():
+    # 1000 m = 3280.84 ft
+    assert m_to_elevation(1000.0, "imperial") == pytest.approx(3280.84, rel=1e-4)
+
+
+def test_s_per_km_to_pace_seconds_metric_identity():
+    assert s_per_km_to_pace_seconds(360.0, "metric") == pytest.approx(360.0)
+
+
+def test_s_per_km_to_pace_seconds_imperial():
+    # 6:00/km × 1.60934 = 9:39.6/mi (579.36s)
+    assert s_per_km_to_pace_seconds(360.0, "imperial") == pytest.approx(579.36, rel=1e-3)
+
+
+def test_s_per_km_to_speed_metric():
+    # 6:00/km = 10 km/h
+    assert s_per_km_to_speed(360.0, "metric") == pytest.approx(10.0, rel=1e-4)
+
+
+def test_s_per_km_to_speed_imperial():
+    # 10 km/h ≈ 6.21 mph
+    assert s_per_km_to_speed(360.0, "imperial") == pytest.approx(6.21371, rel=1e-3)
+
+
+def test_s_per_km_to_speed_zero_or_negative():
+    assert s_per_km_to_speed(0.0, "metric") is None
+    assert s_per_km_to_speed(-1.0, "imperial") is None
+
+
+# ── Round-trip ────────────────────────────────────────────────────────────────
+
+
+def test_imperial_input_to_km_metric_passthrough():
+    assert imperial_input_to_km(10.0, "metric") == pytest.approx(10.0)
+
+
+def test_imperial_input_to_km_imperial():
+    # 10 mi → 16.0934 km
+    assert imperial_input_to_km(10.0, "imperial") == pytest.approx(16.0934, rel=1e-4)
+
+
+def test_imperial_input_to_m_metric_passthrough():
+    assert imperial_input_to_m(100.0, "metric") == pytest.approx(100.0)
+
+
+def test_imperial_input_to_m_imperial():
+    # 1000 ft → 304.8 m
+    assert imperial_input_to_m(1000.0, "imperial") == pytest.approx(304.8, rel=1e-4)
+
+
+def test_round_trip_distance_imperial():
+    # km → mi → km should be lossless to numerical precision
+    km = 12.5
+    mi = km_to_distance(km, "imperial")
+    back = imperial_input_to_km(mi, "imperial")
+    assert back == pytest.approx(km, rel=1e-6)
+
+
+def test_round_trip_elevation_imperial():
+    m = 250.0
+    ft = m_to_elevation(m, "imperial")
+    back = imperial_input_to_m(ft, "imperial")
+    assert back == pytest.approx(m, rel=1e-5)
+
+
+# ── Formatters ────────────────────────────────────────────────────────────────
+
+
+def test_format_distance_imperial():
+    # 5000 m = 3.11 mi
+    assert format_distance(5000, "imperial") == "3.11mi"
+
+
+def test_format_distance_metric():
+    assert format_distance(5000, "metric") == "5.00km"
+
+
+def test_format_distance_none():
+    assert format_distance(None, "metric") == "—"
+
+
+def test_format_pace_metric():
+    assert format_pace(360.0, "metric") == "6:00/km"
+
+
+def test_format_pace_imperial():
+    # 6:00/km × 1.60934 = 9:39 (579.36s → 9 min 39 s)
+    assert format_pace(360.0, "imperial") == "9:39/mi"
+
+
+def test_format_pace_none():
+    assert format_pace(None, "metric") == "—"
+
+
+def test_format_speed_metric():
+    assert format_speed(360.0, "metric") == "10.0km/h"
+
+
+def test_format_speed_imperial():
+    assert format_speed(360.0, "imperial") == "6.2mph"
+
+
+def test_format_elevation_imperial():
+    assert format_elevation(1000.0, "imperial") == "3281ft"
+
+
+def test_format_elevation_metric():
+    assert format_elevation(1000.0, "metric") == "1000m"
+
+
+def test_format_weight_imperial():
+    assert format_weight(100.0, "imperial") == "220lb"
+
+
+def test_format_weight_metric():
+    assert format_weight(100.0, "metric") == "100kg"
+
+
+# ── llm_unit_instruction ──────────────────────────────────────────────────────
+
+
+def test_llm_unit_instruction_running_metric():
+    s = llm_unit_instruction("running", "metric")
+    assert "km" in s and "min/km" in s
+
+
+def test_llm_unit_instruction_running_imperial():
+    s = llm_unit_instruction("running", "imperial")
+    assert "mi" in s and "min/mi" in s
+    assert "km" not in s
+
+
+def test_llm_unit_instruction_cycling_imperial_uses_mph():
+    s = llm_unit_instruction("cycling", "imperial")
+    assert "mph" in s
+    assert "km/h" not in s
+
+
+def test_llm_unit_instruction_lifting_imperial():
+    s = llm_unit_instruction("lifting", "imperial")
+    assert "lb" in s
+    assert "kg" not in s
+
+
+def test_llm_unit_instruction_lifting_metric():
+    s = llm_unit_instruction("lifting", "metric")
+    assert "kg" in s
+    assert "lb" not in s

--- a/web/src/UnitsContext.tsx
+++ b/web/src/UnitsContext.tsx
@@ -1,0 +1,92 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Units } from "./units";
+
+interface UnitsContextValue {
+  units: Units;
+  setUnits: (next: Units) => Promise<void>;
+  loaded: boolean;
+}
+
+const UnitsContext = createContext<UnitsContextValue | null>(null);
+
+const LEGACY_LS_KEY = "strides_unit"; // used to be "miles" | "km" on Charts page
+
+function migrateLegacyLocalStorage(): Units | null {
+  const raw = localStorage.getItem(LEGACY_LS_KEY);
+  if (raw === "miles") {
+    localStorage.removeItem(LEGACY_LS_KEY);
+    return "imperial";
+  }
+  if (raw === "km") {
+    localStorage.removeItem(LEGACY_LS_KEY);
+    return "metric";
+  }
+  return null;
+}
+
+export function UnitsProvider({ children }: { children: ReactNode }) {
+  const [units, setUnitsState] = useState<Units>("metric");
+  const [loaded, setLoaded] = useState(false);
+
+  // Load from server; if server has no preference yet, migrate legacy localStorage
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/settings")
+      .then((r) => r.json())
+      .then(async (data: { units?: Units }) => {
+        if (cancelled) return;
+        const serverUnits: Units | undefined = data.units;
+        const legacy = migrateLegacyLocalStorage();
+        if (legacy && (!serverUnits || serverUnits === "metric")) {
+          // First-run migration: legacy preference exists, server hasn't been told yet.
+          await fetch("/api/settings", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ units: legacy }),
+          }).catch(() => {});
+          if (!cancelled) setUnitsState(legacy);
+        } else if (serverUnits) {
+          setUnitsState(serverUnits);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setUnits = useCallback(async (next: Units) => {
+    setUnitsState(next); // optimistic
+    try {
+      await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ units: next }),
+      });
+    } catch {
+      // best-effort; UI already updated
+    }
+  }, []);
+
+  const value = useMemo(() => ({ units, setUnits, loaded }), [units, setUnits, loaded]);
+  return <UnitsContext.Provider value={value}>{children}</UnitsContext.Provider>;
+}
+
+export function useUnits(): UnitsContextValue {
+  const ctx = useContext(UnitsContext);
+  if (!ctx) {
+    throw new Error("useUnits must be used inside <UnitsProvider>");
+  }
+  return ctx;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { UnitsProvider } from "./UnitsContext";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <UnitsProvider>
+      <App />
+    </UnitsProvider>
   </StrictMode>
 );

--- a/web/src/pages/Activities.tsx
+++ b/web/src/pages/Activities.tsx
@@ -2,6 +2,18 @@ import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Mode, ThemeConfig } from "../App";
+import { useUnits } from "../UnitsContext";
+import {
+  distUnitLabel,
+  elevUnitLabel,
+  formatPace,
+  formatSpeed,
+  kgToWeight,
+  mToDistance,
+  mToElevation,
+  weightUnitLabel,
+  type Units,
+} from "../units";
 
 interface Activity {
   id: number;
@@ -52,18 +64,6 @@ type SortKey =
   | "total_volume_kg" | "total_sets";
 type SortDir = "asc" | "desc";
 
-function formatPace(s: number | null): string {
-  if (!s) return "—";
-  const mins = Math.floor(s / 60);
-  const secs = Math.floor(s % 60);
-  return `${mins}:${String(secs).padStart(2, "0")}/km`;
-}
-
-function formatSpeed(s: number | null): string {
-  if (!s || s <= 0) return "—";
-  return `${(3600 / s).toFixed(1)} km/h`;
-}
-
 function formatDuration(s: number): string {
   const h = Math.floor(s / 3600);
   const m = Math.floor((s % 3600) / 60);
@@ -73,14 +73,21 @@ function formatDuration(s: number): string {
 }
 
 function formatPaceFade(s: number | null): string {
+  // pace_fade_seconds is stored as s/mi by the analysis pipeline (a deferred
+  // unification — see plan). Display in s/mi regardless of preference for now.
   if (s === null) return "—";
   const abs = Math.round(Math.abs(s));
   return s > 0 ? `+${abs}s/mi` : `−${abs}s/mi`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function formatSet(s: any): string {
-  const weight = s.weight_kg != null ? `${s.weight_kg} kg` : "BW";
+function formatSet(s: any, units: Units): string {
+  const w = s.weight_kg;
+  let weight = "BW";
+  if (w != null) {
+    const v = kgToWeight(w, units) ?? 0;
+    weight = `${v.toFixed(units === "imperial" ? 1 : 0)} ${weightUnitLabel(units)}`;
+  }
   if (s.reps != null) return `${weight} × ${s.reps}`;
   if (s.duration_seconds != null) return `${weight} × ${s.duration_seconds}s`;
   if (s.distance_meters != null) return `${weight} × ${s.distance_meters}m`;
@@ -173,7 +180,7 @@ function HrZonesBar({ a }: { a: Activity }) {
 }
 
 /** Exercise breakdown panel section for lifting workouts. */
-function ExerciseBreakdown({ exercises_json }: { exercises_json: string }) {
+function ExerciseBreakdown({ exercises_json, units }: { exercises_json: string; units: Units }) {
   const [showAll, setShowAll] = useState(false);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -210,11 +217,11 @@ function ExerciseBreakdown({ exercises_json }: { exercises_json: string }) {
               <div className="flex flex-wrap gap-x-3 gap-y-1">
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {warmupSets.map((s: any, j: number) => (
-                  <span key={`w${j}`} className="text-xs text-gray-600 italic">{formatSet(s)}</span>
+                  <span key={`w${j}`} className="text-xs text-gray-600 italic">{formatSet(s, units)}</span>
                 ))}
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {workingSets.map((s: any, j: number) => (
-                  <span key={j} className="text-xs text-gray-400">{formatSet(s)}</span>
+                  <span key={j} className="text-xs text-gray-400">{formatSet(s, units)}</span>
                 ))}
               </div>
             </div>
@@ -234,6 +241,7 @@ function ExerciseBreakdown({ exercises_json }: { exercises_json: string }) {
 }
 
 export default function Activities({ mode, theme }: Props) {
+  const { units } = useUnits();
   const [activities, setActivities] = useState<Activity[]>([]);
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
@@ -387,7 +395,10 @@ export default function Activities({ mode, theme }: Props) {
     }
     if (dateFrom) rows = rows.filter((a) => a.date >= dateFrom);
     if (dateTo)   rows = rows.filter((a) => a.date <= dateTo);
-    if (!isLifting && minDist) rows = rows.filter((a) => (a.distance_m ?? 0) / 1000 >= parseFloat(minDist));
+    if (!isLifting && minDist) {
+      const minMeters = parseFloat(minDist) / (units === "imperial" ? 0.000621371 : 0.001);
+      rows = rows.filter((a) => (a.distance_m ?? 0) >= minMeters);
+    }
 
     return [...rows].sort((a, b) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -435,8 +446,8 @@ export default function Activities({ mode, theme }: Props) {
 
   function paceLabel2(a: Activity): string {
     const isCycle = a.sport_type === "Ride" || a.sport_type === "VirtualRide" || a.sport_type === "GravelRide";
-    if (mode === "cycling" || isCycle) return formatSpeed(a.avg_pace_s_per_km);
-    return formatPace(a.avg_pace_s_per_km);
+    if (mode === "cycling" || isCycle) return formatSpeed(a.avg_pace_s_per_km, units);
+    return formatPace(a.avg_pace_s_per_km, units);
   }
 
   const hasMetrics = selectedActivity && (
@@ -503,7 +514,7 @@ export default function Activities({ mode, theme }: Props) {
         {!isLifting && (
           <input
             type="number"
-            placeholder="Min km"
+            placeholder={`Min ${distUnitLabel(units)}`}
             value={minDist}
             onChange={(e) => setMinDist(e.target.value)}
             min="0"
@@ -533,7 +544,7 @@ export default function Activities({ mode, theme }: Props) {
                   <>
                     <Th label="Date"        col="date" />
                     <Th label="Name"        col="name" />
-                    <Th label="Volume (kg)" col="total_volume_kg"  right />
+                    <Th label={`Volume (${weightUnitLabel(units)})`} col="total_volume_kg"  right />
                     <Th label="Time"        col="moving_time_s"    right />
                     <Th label="Sets"        col="total_sets"       right />
                     <th className="px-4 py-2 font-medium whitespace-nowrap text-right text-gray-400">Exercises</th>
@@ -543,11 +554,11 @@ export default function Activities({ mode, theme }: Props) {
                   <>
                     <Th label="Date"      col="date" />
                     <Th label="Name"      col="name" />
-                    <Th label="Dist (km)" col="distance_m"       right />
+                    <Th label={`Dist (${distUnitLabel(units)})`} col="distance_m"       right />
                     <Th label="Time"      col="moving_time_s"     right />
                     <Th label={paceLabel} col="avg_pace_s_per_km" right />
                     <Th label="Avg HR"    col="avg_hr"            right />
-                    <Th label="Elev (m)"  col="elevation_gain_m"  right />
+                    <Th label={`Elev (${elevUnitLabel(units)})`}  col="elevation_gain_m"  right />
                     <th className="px-4 py-2 font-medium whitespace-nowrap text-right"></th>
                   </>
                 )}
@@ -583,7 +594,9 @@ export default function Activities({ mode, theme }: Props) {
                     {isLifting ? (
                       <>
                         <td className="px-4 py-2 text-right text-gray-100">
-                          {a.total_volume_kg != null ? a.total_volume_kg.toFixed(0) : "—"}
+                          {a.total_volume_kg != null
+                            ? (kgToWeight(a.total_volume_kg, units) ?? 0).toFixed(0)
+                            : "—"}
                         </td>
                         <td className="px-4 py-2 text-right text-gray-400">
                           {formatDuration(a.moving_time_s)}
@@ -598,25 +611,27 @@ export default function Activities({ mode, theme }: Props) {
                     ) : (
                       <>
                         <td className="px-4 py-2 text-right text-gray-100">
-                          {((a.distance_m || 0) / 1000).toFixed(2)}
+                          {(mToDistance(a.distance_m, units) ?? 0).toFixed(2)}
                         </td>
                         <td className="px-4 py-2 text-right text-gray-400">
                           {formatDuration(a.moving_time_s)}
                         </td>
                         <td className="px-4 py-2 text-right text-gray-400">
                           {mode === "cycling"
-                            ? formatSpeed(a.avg_pace_s_per_km)
+                            ? formatSpeed(a.avg_pace_s_per_km, units)
                             : mode === "hybrid"
                             ? (a.sport_type === "Ride" || a.sport_type === "VirtualRide" || a.sport_type === "GravelRide"
-                                ? formatSpeed(a.avg_pace_s_per_km)
-                                : formatPace(a.avg_pace_s_per_km))
-                            : formatPace(a.avg_pace_s_per_km)}
+                                ? formatSpeed(a.avg_pace_s_per_km, units)
+                                : formatPace(a.avg_pace_s_per_km, units))
+                            : formatPace(a.avg_pace_s_per_km, units)}
                         </td>
                         <td className="px-4 py-2 text-right text-gray-400">
                           {a.avg_hr ?? "—"}
                         </td>
                         <td className="px-4 py-2 text-right text-gray-400">
-                          {a.elevation_gain_m != null ? Math.round(a.elevation_gain_m) : "—"}
+                          {a.elevation_gain_m != null
+                            ? Math.round(mToElevation(a.elevation_gain_m, units) ?? 0)
+                            : "—"}
                         </td>
                       </>
                     )}
@@ -685,8 +700,12 @@ export default function Activities({ mode, theme }: Props) {
               {isLifting ? (
                 <div className="grid grid-cols-4 gap-2">
                   <MetricTile
-                    label="Volume (kg)"
-                    value={selectedActivity.total_volume_kg != null ? selectedActivity.total_volume_kg.toFixed(0) : "—"}
+                    label={`Volume (${weightUnitLabel(units)})`}
+                    value={
+                      selectedActivity.total_volume_kg != null
+                        ? (kgToWeight(selectedActivity.total_volume_kg, units) ?? 0).toFixed(0)
+                        : "—"
+                    }
                   />
                   <MetricTile
                     label="Time"
@@ -705,7 +724,7 @@ export default function Activities({ mode, theme }: Props) {
                 <div className="grid grid-cols-4 gap-2">
                   <MetricTile
                     label="Distance"
-                    value={`${((selectedActivity.distance_m || 0) / 1000).toFixed(2)} km`}
+                    value={`${(mToDistance(selectedActivity.distance_m, units) ?? 0).toFixed(2)} ${distUnitLabel(units)}`}
                   />
                   <MetricTile
                     label="Time"
@@ -724,7 +743,7 @@ export default function Activities({ mode, theme }: Props) {
 
               {/* Exercise breakdown — lifting only */}
               {isLifting && selectedActivity.exercises_json && (
-                <ExerciseBreakdown exercises_json={selectedActivity.exercises_json} />
+                <ExerciseBreakdown exercises_json={selectedActivity.exercises_json} units={units} />
               )}
 
               {/* Analysis summary */}

--- a/web/src/pages/Calendar.tsx
+++ b/web/src/pages/Calendar.tsx
@@ -1,4 +1,16 @@
 import { useCallback, useEffect, useState } from "react";
+import { useUnits } from "../UnitsContext";
+import {
+  distUnitLabel,
+  elevUnitLabel,
+  formatPace,
+  imperialInputToKm,
+  imperialInputToM,
+  kmToDistance,
+  kmToUserUnit,
+  mToElevation,
+  mToUserElevation,
+} from "../units";
 
 const DAYS_OF_WEEK = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
@@ -81,16 +93,12 @@ function fmtDuration(seconds: number): string {
   return `${m}m ${s.toString().padStart(2, "0")}s`;
 }
 
-function fmtPace(sPerKm: number | null): string {
-  if (!sPerKm) return "—";
-  const m = Math.floor(sPerKm / 60);
-  const s = Math.round(sPerKm % 60);
-  return `${m}:${s.toString().padStart(2, "0")}/km`;
-}
+// fmtPace removed — use formatPace from "../units" with current units context.
 
 const RUN_TYPES = new Set(["Run", "TrailRun", "VirtualRun"]);
 
 export default function Calendar() {
+  const { units } = useUnits();
   const today = new Date();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
 
@@ -175,11 +183,14 @@ export default function Calendar() {
 
   const saveWorkout = async () => {
     if (!selectedDate) return;
+    // Form values are entered in the user's preferred unit; convert back to canonical SI.
+    const distInput = form.distance_km ? parseFloat(form.distance_km) : null;
+    const elevInput = form.elevation_m ? parseFloat(form.elevation_m) : null;
     const body = {
       workout_type: form.workout_type,
       description: form.description || null,
-      distance_km: form.distance_km ? parseFloat(form.distance_km) : null,
-      elevation_m: form.elevation_m ? parseFloat(form.elevation_m) : null,
+      distance_km: imperialInputToKm(distInput, units),
+      elevation_m: imperialInputToM(elevInput, units),
       duration_min: form.duration_min ? parseInt(form.duration_min) : null,
       intensity: form.intensity,
     };
@@ -236,8 +247,12 @@ export default function Calendar() {
     setForm(existing ? {
       workout_type: existing.workout_type || "Easy Run",
       description: existing.description || "",
-      distance_km: existing.distance_km?.toString() || "",
-      elevation_m: existing.elevation_m?.toString() || "",
+      distance_km: existing.distance_km != null
+        ? (kmToUserUnit(existing.distance_km, units) ?? 0).toFixed(2)
+        : "",
+      elevation_m: existing.elevation_m != null
+        ? (mToUserElevation(existing.elevation_m, units) ?? 0).toFixed(0)
+        : "",
       duration_min: existing.duration_min?.toString() || "",
       intensity: existing.intensity || "easy",
     } : EMPTY_FORM);
@@ -248,8 +263,12 @@ export default function Calendar() {
     setForm({
       workout_type: existing?.workout_type || "Easy Run",
       description: existing?.description || "",
-      distance_km: existing?.distance_km?.toString() || "",
-      elevation_m: existing?.elevation_m?.toString() || "",
+      distance_km: existing?.distance_km != null
+        ? (kmToUserUnit(existing.distance_km, units) ?? 0).toFixed(2)
+        : "",
+      elevation_m: existing?.elevation_m != null
+        ? (mToUserElevation(existing.elevation_m, units) ?? 0).toFixed(0)
+        : "",
       duration_min: existing?.duration_min?.toString() || "",
       intensity: existing?.intensity || "easy",
     });
@@ -402,6 +421,8 @@ export default function Calendar() {
                   (s, a) => s + (a.distance_m ?? 0) / 1000, 0
                 );
               }, 0);
+              const plannedDisplay = kmToDistance(plannedKm, units) ?? 0;
+              const actualDisplay = kmToDistance(actualKm, units) ?? 0;
 
               return (
                 <div key={wi} className="flex gap-1 mb-3">
@@ -439,13 +460,17 @@ export default function Calendar() {
                           <div className={`text-xs px-1 py-0.5 rounded border truncate mb-0.5 ${WORKOUT_COLORS[workout.workout_type] ?? "bg-zinc-700/50 text-zinc-400 border-zinc-600/30"}`}>
                             {workout.workout_type}
                             {workout.distance_km && (
-                              <span className="ml-1 opacity-70">{workout.distance_km}k</span>
+                              <span className="ml-1 opacity-70">
+                                {(kmToDistance(workout.distance_km, units) ?? 0).toFixed(1)}
+                                {distUnitLabel(units) === "mi" ? "mi" : "k"}
+                              </span>
                             )}
                           </div>
                         )}
                         {dayActivities.map(a => (
                           <div key={a.id} className="text-xs px-1 py-0.5 rounded bg-zinc-600/40 text-zinc-300 border border-zinc-600/40 truncate mb-0.5">
-                            ✓ {((a.distance_m ?? 0) / 1000).toFixed(1)}k {a.sport_type}
+                            ✓ {((kmToDistance((a.distance_m ?? 0) / 1000, units)) ?? 0).toFixed(1)}
+                            {distUnitLabel(units) === "mi" ? "mi" : "k"} {a.sport_type}
                           </div>
                         ))}
                       </div>
@@ -457,16 +482,16 @@ export default function Calendar() {
                     <div>
                       <div className="text-[10px] text-zinc-500 uppercase tracking-wider mb-0.5">Planned</div>
                       <div className="text-sm text-zinc-300 font-semibold">
-                        {plannedKm > 0 ? `${plannedKm.toFixed(1)}` : "—"}
+                        {plannedKm > 0 ? `${plannedDisplay.toFixed(1)}` : "—"}
                       </div>
-                      {plannedKm > 0 && <div className="text-[10px] text-zinc-500">km</div>}
+                      {plannedKm > 0 && <div className="text-[10px] text-zinc-500">{distUnitLabel(units)}</div>}
                     </div>
                     <div>
                       <div className="text-[10px] text-zinc-500 uppercase tracking-wider mb-0.5">Actual</div>
                       <div className={`text-sm font-semibold ${actualKm > 0 ? "text-green-400" : "text-zinc-600"}`}>
-                        {actualKm > 0 ? `${actualKm.toFixed(1)}` : "—"}
+                        {actualKm > 0 ? `${actualDisplay.toFixed(1)}` : "—"}
                       </div>
-                      {actualKm > 0 && <div className="text-[10px] text-zinc-500">km</div>}
+                      {actualKm > 0 && <div className="text-[10px] text-zinc-500">{distUnitLabel(units)}</div>}
                     </div>
                   </div>
                 </div>
@@ -518,7 +543,9 @@ export default function Calendar() {
                         {selectedWorkout.distance_km && (
                           <div className="bg-zinc-800 rounded p-2 text-xs">
                             <div className="text-zinc-500">Distance</div>
-                            <div className="text-zinc-200 font-medium">{selectedWorkout.distance_km} km</div>
+                            <div className="text-zinc-200 font-medium">
+                              {(kmToDistance(selectedWorkout.distance_km, units) ?? 0).toFixed(2)} {distUnitLabel(units)}
+                            </div>
                           </div>
                         )}
                         {selectedWorkout.duration_min && (
@@ -530,7 +557,9 @@ export default function Calendar() {
                         {selectedWorkout.elevation_m && (
                           <div className="bg-zinc-800 rounded p-2 text-xs">
                             <div className="text-zinc-500">Elevation</div>
-                            <div className="text-zinc-200 font-medium">{selectedWorkout.elevation_m} m</div>
+                            <div className="text-zinc-200 font-medium">
+                              {(mToElevation(selectedWorkout.elevation_m, units) ?? 0).toFixed(0)} {elevUnitLabel(units)}
+                            </div>
                           </div>
                         )}
                       </div>
@@ -567,7 +596,7 @@ export default function Calendar() {
                     </div>
                     <div className="grid grid-cols-2 gap-2">
                       <div>
-                        <label className="text-xs text-zinc-500 mb-1 block">Distance (km)</label>
+                        <label className="text-xs text-zinc-500 mb-1 block">Distance ({distUnitLabel(units)})</label>
                         <input
                           type="number" step="0.1" placeholder="—"
                           value={form.distance_km}
@@ -576,7 +605,7 @@ export default function Calendar() {
                         />
                       </div>
                       <div>
-                        <label className="text-xs text-zinc-500 mb-1 block">Elevation (m)</label>
+                        <label className="text-xs text-zinc-500 mb-1 block">Elevation ({elevUnitLabel(units)})</label>
                         <input
                           type="number" placeholder="—"
                           value={form.elevation_m}
@@ -635,7 +664,7 @@ export default function Calendar() {
                 <div className="w-44 flex-shrink-0 space-y-2">
                   <h4 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">Strava</h4>
                   {selectedActivities.map(a => {
-                    const distKm = ((a.distance_m ?? 0) / 1000).toFixed(2);
+                    const distDisplay = (kmToDistance((a.distance_m ?? 0) / 1000, units) ?? 0).toFixed(2);
                     const isRun = RUN_TYPES.has(a.sport_type);
                     return (
                       <div key={a.id} className="bg-zinc-800/60 rounded p-2 border border-zinc-700/50 space-y-1">
@@ -643,13 +672,13 @@ export default function Calendar() {
                         <div className="text-xs text-zinc-500">{a.sport_type}</div>
                         <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs">
                           <span className="text-zinc-500">Distance</span>
-                          <span className="text-zinc-300">{distKm} km</span>
+                          <span className="text-zinc-300">{distDisplay} {distUnitLabel(units)}</span>
                           <span className="text-zinc-500">Duration</span>
                           <span className="text-zinc-300">{fmtDuration(a.moving_time_s)}</span>
                           {isRun && a.avg_pace_s_per_km && (
                             <>
                               <span className="text-zinc-500">Pace</span>
-                              <span className="text-zinc-300">{fmtPace(a.avg_pace_s_per_km)}</span>
+                              <span className="text-zinc-300">{formatPace(a.avg_pace_s_per_km, units)}</span>
                             </>
                           )}
                           {a.avg_hr && (
@@ -661,7 +690,9 @@ export default function Calendar() {
                           {a.elevation_gain_m != null && (
                             <>
                               <span className="text-zinc-500">Elevation</span>
-                              <span className="text-zinc-300">{Math.round(a.elevation_gain_m)} m</span>
+                              <span className="text-zinc-300">
+                                {Math.round(mToElevation(a.elevation_gain_m, units) ?? 0)} {elevUnitLabel(units)}
+                              </span>
                             </>
                           )}
                         </div>

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -306,6 +306,10 @@ export default function Profile({ mode, theme }: Props) {
           <p className="text-xs text-gray-500 mt-0.5">
             Loaded fresh every session — tell your coach who you are.
           </p>
+          <p className="text-xs text-gray-600 italic mt-1">
+            Free-text fields (height, weight, weekly volume, etc.) are stored as you typed them —
+            re-enter them if you change your units preference.
+          </p>
         </div>
         <div className="flex items-center gap-3">
           {saved && <span className={`text-sm ${theme.accentClass}`}>Saved!</span>}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, type Dispatch, type SetStateAction } from "react";
 import type { Mode, ThemeConfig } from "../App";
+import { useUnits } from "../UnitsContext";
+import type { Units } from "../units";
 
 interface Provider {
   id: string;
@@ -80,6 +82,7 @@ const VOICE_OPTIONS: { value: string; label: string; description: string }[] = [
 const PRESET_VOICE_VALUES = new Set(VOICE_OPTIONS.map((o) => o.value).filter((v) => v !== "custom"));
 
 export default function Settings({ mode, setMode, theme, onProviderChanged }: Props) {
+  const { units, setUnits } = useUnits();
   const [syncState, setSyncState] = useState<SyncState>("idle");
   const [syncCount, setSyncCount] = useState<number | null>(null);
   const [hevySyncState, setHevySyncState] = useState<SyncState>("idle");
@@ -271,6 +274,50 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
                       )}
                     </div>
                     <p className="text-xs text-gray-500 pl-5">{card.description}</p>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+              Units
+            </h3>
+            <p className="text-xs text-gray-600 mb-3">
+              Switches the entire app between metric (km, kg, m, min/km) and imperial
+              (mi, lb, ft, min/mi). Coaching responses follow the same preference. New activity
+              analyses are written in both units; older summaries keep their original unit.
+            </p>
+            <div className="flex gap-3">
+              {(
+                [
+                  { id: "metric" as Units, label: "Metric", desc: "km · kg · m · min/km · km/h" },
+                  { id: "imperial" as Units, label: "Imperial", desc: "mi · lb · ft · min/mi · mph" },
+                ]
+              ).map((opt) => {
+                const selected = units === opt.id;
+                return (
+                  <button
+                    key={opt.id}
+                    onClick={() => setUnits(opt.id)}
+                    className={`flex-1 text-left p-4 rounded-lg border-2 transition-colors bg-gray-900 ${
+                      selected ? "border-gray-300" : "border-gray-700 hover:border-gray-500"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <span
+                        className={`font-medium text-sm ${
+                          selected ? theme.accentClass : "text-gray-200"
+                        }`}
+                      >
+                        {opt.label}
+                      </span>
+                      {selected && (
+                        <span className={`ml-auto text-xs ${theme.accentClass}`}>Active</span>
+                      )}
+                    </div>
+                    <p className="text-xs text-gray-500">{opt.desc}</p>
                   </button>
                 );
               })}

--- a/web/src/pages/charts/CardioCharts.tsx
+++ b/web/src/pages/charts/CardioCharts.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Mode, ThemeConfig } from "../../App";
+import { useUnits } from "../../UnitsContext";
+import { distUnitLabel } from "../../units";
 import FilterBar from "../../charts/FilterBar";
 import ScatterTrendCard from "../../charts/ScatterTrendCard";
 import TimeSeriesLineCard from "../../charts/TimeSeriesLineCard";
@@ -137,9 +139,8 @@ function AerobicEffTooltip({
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function CardioCharts({ mode, theme }: Props) {
-  const [unit, setUnit] = useState<Unit>(() => {
-    return (localStorage.getItem("strides_unit") as Unit) || "miles";
-  });
+  const { units } = useUnits();
+  const unit: Unit = units === "imperial" ? "miles" : "km";
   const [data, setData] = useState<ChartData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -149,10 +150,9 @@ export default function CardioCharts({ mode, theme }: Props) {
   const [customUntil, setCustomUntil] = useState("");
 
   useEffect(() => {
-    localStorage.setItem("strides_unit", unit);
     setLoading(true);
     setError(null);
-    fetch(`/api/charts?unit=${unit}&mode=${mode}`)
+    fetch(`/api/charts?mode=${mode}`)
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();
@@ -165,7 +165,7 @@ export default function CardioCharts({ mode, theme }: Props) {
         setError(e.message);
         setLoading(false);
       });
-  }, [unit, mode]);
+  }, [units, mode]);
 
   const range = useMemo((): DateRange => {
     if (preset === "custom") return { since: customSince || null, until: customUntil || null };
@@ -226,21 +226,9 @@ export default function CardioCharts({ mode, theme }: Props) {
       <div className="p-6 space-y-5 max-w-5xl mx-auto">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-bold text-gray-100">Training Charts</h2>
-          <div className="flex rounded-md overflow-hidden border border-gray-700 text-sm">
-            {(["miles", "km"] as Unit[]).map((u) => (
-              <button
-                key={u}
-                onClick={() => setUnit(u)}
-                className={`px-4 py-1.5 transition-colors ${
-                  unit === u
-                    ? `${theme.accentBg} ${theme.accentClass} font-medium`
-                    : "text-gray-400 hover:bg-gray-800"
-                }`}
-              >
-                {u === "miles" ? "Miles" : "km"}
-              </button>
-            ))}
-          </div>
+          <span className="text-xs text-gray-500">
+            Units: {distUnitLabel(units)} · change in Settings
+          </span>
         </div>
 
         <FilterBar

--- a/web/src/pages/charts/LiftingCharts.tsx
+++ b/web/src/pages/charts/LiftingCharts.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ThemeConfig } from "../../App";
+import { useUnits } from "../../UnitsContext";
+import { weightUnitLabel } from "../../units";
 import FilterBar from "../../charts/FilterBar";
 import StackedBarCard, { type StackedCategory } from "../../charts/StackedBarCard";
 import TimeSeriesLineCard, { type SeriesSpec } from "../../charts/TimeSeriesLineCard";
@@ -68,6 +70,8 @@ function pivotOneRm(series: Record<string, OneRMPoint[]>): Record<string, unknow
 }
 
 export default function LiftingCharts({ theme }: Props) {
+  const { units } = useUnits();
+  const wLabel = weightUnitLabel(units);
   const [data, setData] = useState<LiftingChartData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -91,7 +95,7 @@ export default function LiftingCharts({ theme }: Props) {
         setError(e.message);
         setLoading(false);
       });
-  }, []);
+  }, [units]);
 
   const range = useMemo((): DateRange => {
     if (preset === "custom") return { since: customSince || null, until: customUntil || null };
@@ -199,9 +203,9 @@ export default function LiftingCharts({ theme }: Props) {
             <WeeklyBarCard
               title="Weekly Training Volume"
               data={filtered.weekly_volume}
-              unitLabel="kg"
+              unitLabel={wLabel}
               valueLabel="Volume"
-              formatValue={(n) => `${n.toLocaleString(undefined, { maximumFractionDigits: 0 })} kg`}
+              formatValue={(n) => `${n.toLocaleString(undefined, { maximumFractionDigits: 0 })} ${wLabel}`}
             />
 
             {filtered.one_rm_progression.exercises.length > 0 ? (
@@ -214,8 +218,8 @@ export default function LiftingCharts({ theme }: Props) {
                 yAxes={[
                   {
                     id: "y",
-                    tickFormatter: (v) => `${v}kg`,
-                    label: "kg",
+                    tickFormatter: (v) => `${v}${wLabel}`,
+                    label: wLabel,
                   },
                 ]}
               />

--- a/web/src/units.ts
+++ b/web/src/units.ts
@@ -1,0 +1,151 @@
+// Central unit conversion module — mirrors strides_ai/units.py.
+// All storage in the app stays canonical SI; these helpers run at the display
+// layer (and at form-submit time for the Calendar planner).
+
+export type Units = "metric" | "imperial";
+
+export const VALID_UNITS = new Set<Units>(["metric", "imperial"]);
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const M_TO_MI = 0.000621371;
+export const M_TO_KM = 0.001;
+export const KG_TO_LB = 2.20462;
+export const M_TO_FT = 3.28084;
+export const S_PER_KM_TO_S_PER_MI = 1.60934;
+
+// ── Labels ────────────────────────────────────────────────────────────────────
+
+export function distUnitLabel(units: Units): string {
+  return units === "imperial" ? "mi" : "km";
+}
+
+export function weightUnitLabel(units: Units): string {
+  return units === "imperial" ? "lb" : "kg";
+}
+
+export function elevUnitLabel(units: Units): string {
+  return units === "imperial" ? "ft" : "m";
+}
+
+export function speedUnitLabel(units: Units): string {
+  return units === "imperial" ? "mph" : "km/h";
+}
+
+export function paceUnitLabel(units: Units): string {
+  return units === "imperial" ? "min/mi" : "min/km";
+}
+
+// ── Numeric conversions ───────────────────────────────────────────────────────
+
+export function mToDistance(m: number | null | undefined, units: Units): number | null {
+  if (m == null) return null;
+  return m * (units === "imperial" ? M_TO_MI : M_TO_KM);
+}
+
+export function kmToDistance(km: number | null | undefined, units: Units): number | null {
+  if (km == null) return null;
+  return km * 1000 * (units === "imperial" ? M_TO_MI : M_TO_KM);
+}
+
+export function kgToWeight(kg: number | null | undefined, units: Units): number | null {
+  if (kg == null) return null;
+  return units === "imperial" ? kg * KG_TO_LB : kg;
+}
+
+export function mToElevation(m: number | null | undefined, units: Units): number | null {
+  if (m == null) return null;
+  return units === "imperial" ? m * M_TO_FT : m;
+}
+
+export function sPerKmToPaceSeconds(
+  sPerKm: number | null | undefined,
+  units: Units,
+): number | null {
+  if (sPerKm == null) return null;
+  return units === "imperial" ? sPerKm * S_PER_KM_TO_S_PER_MI : sPerKm;
+}
+
+export function sPerKmToSpeed(sPerKm: number | null | undefined, units: Units): number | null {
+  if (sPerKm == null || sPerKm <= 0) return null;
+  const kph = 3600 / sPerKm;
+  return units === "imperial" ? kph * (M_TO_MI / M_TO_KM) : kph;
+}
+
+// ── Round-trip helpers (Calendar form) ────────────────────────────────────────
+
+/** Convert a user-entered distance value to km for backend storage. */
+export function imperialInputToKm(value: number | null | undefined, units: Units): number | null {
+  if (value == null) return null;
+  return units === "imperial" ? value / (M_TO_MI / M_TO_KM) : value;
+}
+
+/** Convert a user-entered elevation value to metres for backend storage. */
+export function imperialInputToM(value: number | null | undefined, units: Units): number | null {
+  if (value == null) return null;
+  return units === "imperial" ? value / M_TO_FT : value;
+}
+
+/** Convert km from backend → user's preferred distance unit (for prefilling forms). */
+export function kmToUserUnit(km: number | null | undefined, units: Units): number | null {
+  if (km == null) return null;
+  return units === "imperial" ? km * (M_TO_MI / M_TO_KM) : km;
+}
+
+/** Convert metres from backend → user's preferred elevation unit (for prefilling forms). */
+export function mToUserElevation(m: number | null | undefined, units: Units): number | null {
+  if (m == null) return null;
+  return units === "imperial" ? m * M_TO_FT : m;
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+
+export function formatDistance(
+  m: number | null | undefined,
+  units: Units,
+  precision = 2,
+): string {
+  const v = mToDistance(m, units);
+  return v == null ? "—" : `${v.toFixed(precision)} ${distUnitLabel(units)}`;
+}
+
+export function formatPace(sPerKm: number | null | undefined, units: Units): string {
+  const s = sPerKmToPaceSeconds(sPerKm, units);
+  if (s == null) return "—";
+  const mins = Math.floor(s / 60);
+  const secs = Math.floor(s % 60);
+  return `${mins}:${String(secs).padStart(2, "0")}/${distUnitLabel(units)}`;
+}
+
+export function formatSpeed(sPerKm: number | null | undefined, units: Units): string {
+  const v = sPerKmToSpeed(sPerKm, units);
+  return v == null ? "—" : `${v.toFixed(1)} ${speedUnitLabel(units)}`;
+}
+
+export function formatElevation(
+  m: number | null | undefined,
+  units: Units,
+  precision = 0,
+): string {
+  const v = mToElevation(m, units);
+  return v == null ? "—" : `${v.toFixed(precision)} ${elevUnitLabel(units)}`;
+}
+
+export function formatWeight(
+  kg: number | null | undefined,
+  units: Units,
+  precision = 0,
+): string {
+  const v = kgToWeight(kg, units);
+  return v == null ? "—" : `${v.toFixed(precision)} ${weightUnitLabel(units)}`;
+}
+
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds == null) return "—";
+  const h = Math.floor(seconds / 3600);
+  const rem = seconds % 3600;
+  const m = Math.floor(rem / 60);
+  const s = Math.floor(rem % 60);
+  if (h > 0) return `${h}h${String(m).padStart(2, "0")}m${String(s).padStart(2, "0")}s`;
+  return `${m}m${String(s).padStart(2, "0")}s`;
+}


### PR DESCRIPTION
## Summary

Adds a single Settings toggle that flips the entire UI **and** the LLM coaching
language between **metric** (km, kg, m, min/km, km/h) and **imperial** (mi, lb,
ft, min/mi, mph). All storage stays canonical SI; conversion happens at the
display layer plus one round-trip in the Calendar planner form so existing
data migrates without a database change.

> **Stacked PR.** Targets `feat/charts-lifting-mode` (#TBD) because the units
> work touches lifting chart code that doesn't exist on `main` yet. When the
> parent merges, GitHub will retarget this PR to `main` automatically.

## Why

The app was metric-native: distances stored as metres, weights as kg, paces as
s/km. Imperial-region athletes saw km / min-per-km / kg everywhere with no way
to flip. The Charts page already had a per-page Miles/km toggle, but it was
isolated to one tab, used `localStorage`, and didn't affect the LLM. This PR
unifies all of that into one global preference.

## What changed

### Backend

- **New `strides_ai/units.py`** — single source of truth: constants
  (`M_TO_MI`, `KG_TO_LB`, `M_TO_FT`, `S_PER_KM_TO_S_PER_MI`), label helpers
  (`dist_unit_label`, `weight_unit_label`, `elev_unit_label`,
  `pace_unit_label`, `speed_unit_label`), numeric conversions, formatters
  (`format_distance`, `format_pace`, `format_speed`, `format_elevation`,
  `format_weight`, `format_duration`), Calendar round-trip helpers
  (`imperial_input_to_km`, `imperial_input_to_m`), and
  `llm_unit_instruction(mode, units)` for dynamic system-prompt injection.

- **`/api/settings`** — body, GET, and PUT all carry a new \`units\` field
  (\`metric\` | \`imperial\`). Validation against \`VALID_UNITS\`. \`init_backend\`
  is re-triggered on units change so the LLM's seeded conversation history
  picks up the new unit immediately (otherwise the seeded full training log
  would stay in the old unit until the next mode/provider switch or server
  restart).

- **`coach.build_system` + `build_training_log` + `build_initial_history`**
  thread \`units\` through. The per-mode system prompts (\`RUNNING_SYSTEM_PROMPT\`,
  \`CYCLING_SYSTEM_PROMPT\`, \`HYBRID_SYSTEM_PROMPT\`, \`LIFTING_SYSTEM_PROMPT\`)
  no longer hardcode \"Use metric units (km, min/km)…\" — that instruction is
  now injected dynamically by \`llm_unit_instruction\` so the coach actually
  responds in the chosen unit. The planned-workouts table converts km → user
  unit; the pace-fade analysis-guide blurb flips between \`sec/mi\` and \`sec/km\`.

- **`modes.py`** — \`_format_pace\`, \`_format_speed\`, log-row formatters,
  totals, and the column header are all unit-aware. The header is now a
  function \`header(units)\` so \`DIST(km)\` / \`ELEV(m)\` / \`VOLUME(kg)\` swap
  to \`DIST(mi)\` / \`ELEV(ft)\` / \`VOLUME(lb)\` cleanly.

- **`charts_lifting`** — \`compute_weekly_volume\` and
  \`compute_one_rm_progression\` and \`get_chart_data\` accept \`units\`; values
  convert kg → lb when imperial. The point key stays \`one_rm_kg\` for backward
  compatibility with existing tests.

- **`/api/charts`** — drops the legacy \`?unit=miles|km\` query parameter.
  Source of truth is the global settings DB key now. Lifting branch fetches
  the cached HEVY exercise-template muscle map and passes both that and the
  units preference into \`get_lifting_chart_data\`.

- **`analysis.py`** — the rule-based \`analysis_summary\` builder now writes
  **both** unit forms inline going forward (e.g. \`\"pace fade 18s/mi (11s/km)\"\`,
  \`\"Hilly course (120 ft/mi · 23 m/km elevation gain)\"\`). This is a cheap
  mitigation for the cached-text staleness problem — no re-analysis trigger
  needed, and the LLM tolerates redundant unit pairs gracefully. Existing
  rows stay stale (documented limitation; see Deferred).

### Frontend

- **New `web/src/units.ts`** — mirrors `units.py` 1:1.

- **New `web/src/UnitsContext.tsx`** — \`UnitsProvider\` + \`useUnits\` hook.
  Optimistic PUT on change. One-time migration of the legacy Charts-page
  \`localStorage[\"strides_unit\"]\` value into the DB on first load (\`miles\` →
  \`imperial\`, \`km\` → \`metric\`), then drops the localStorage key. Existing
  users keep their preference seamlessly.

- **`main.tsx`** — wraps `App` in `UnitsProvider`.

- **`Settings.tsx`** — new \"Units\" section, sibling to Mode, two-button card
  picker (Metric / Imperial). Lives at the top of the settings page since
  it's a system-wide preference.

- **`Activities.tsx`** — replaces the local \`formatPace\` / \`formatSpeed\` /
  \`(distance_m / 1000)\` / \`(elevation_gain_m | round)\` / \`total_volume_kg\`
  inline math with imports from \`units.ts\`. Table headers (\`Dist (km)\`,
  \`Volume (kg)\`, \`Elev (m)\`) become dynamic. Min-distance filter placeholder
  uses \`distUnitLabel\`. The detail panel \`MetricTile\` for \"Distance\" /
  \"Volume (kg)\" follows suit. \`formatSet\` (per-set weight in the lifting
  exercise breakdown) takes \`units\` and is plumbed through \`ExerciseBreakdown\`.

- **`Calendar.tsx`** — distance and elevation labels dynamic. Workout-edit
  form rounds-trip user input through \`imperialInputToKm\` / \`imperialInputToM\`
  so DB storage stays metric. Existing planned workouts read in user unit
  via \`kmToUserUnit\` / \`mToUserElevation\`. Weekly totals (planned/actual),
  day-cell distance pills, and the Strava activity row in the detail panel
  all flip with the toggle.

- **`Profile.tsx`** — one-line italic warning under the page header that
  free-text fields (height, weight, weekly volume) are stored as-typed and
  must be re-entered if the user changes their unit preference. Conversion
  is intentionally not attempted (see Deferred).

- **`CardioCharts.tsx`** — drops the per-page Miles/km toggle and the
  \`localStorage\` write entirely. Reads units from \`useUnits()\`. The hardcoded
  \`?unit=...\` query string in the fetch URL is gone (backend reads from
  settings now). A small \"Units: <x> · change in Settings\" hint replaces
  the toggle.

- **`LiftingCharts.tsx`** — Y-axis labels and tooltip formatters pull from
  \`weightUnitLabel(units)\`. Re-fetches on units change so the backend
  recomputes lb values.

### Tests

- **`tests/test_units.py`** *(new, 45 tests)* — constants reference values
  (5 km = 3.10686 mi, 100 kg = 220.462 lb, 1000 m = 3280.84 ft, 6:00/km =
  9:39/mi), labels, numeric conversions in both directions, round-trip
  losslessness checks, formatters, and the LLM unit-instruction strings
  for every mode × unit combination.

- **`tests/test_coach.py`** *(extended, +9 tests)* — verifies
  \`build_system(..., units=\"imperial\")\` produces \`min/mi\` for running, \`mph\`
  for cycling, \`lb\` for lifting; the inverse for metric; log headers swap
  \`DIST(km)\`/\`ELEV(m)\`/\`VOLUME(kg)\` ↔ \`DIST(mi)\`/\`ELEV(ft)\`/\`VOLUME(lb)\`
  correctly; totals row in imperial reads in miles.

- **`tests/test_charts_lifting.py`** — one existing test relaxed to a
  subset-check because \`get_chart_data\` now echoes a \`units\` key in its
  response.

**Full suite: 389 passed.** TypeScript: clean.

## Deferred (documented limitations)

1. **Cached `analysis_summary` / `deep_dive_report` strings on existing rows**
   stay in their original unit (typically imperial s/mi for pace fade,
   ft/mi for elevation). New analyses going forward emit both forms
   inline as a cheap mitigation. A future PR can add a \"Re-analyze all\"
   button if it becomes painful in practice.

2. **Free-text profile fields** (height, weight, weekly volume) are stored
   as the user typed them. The app surfaces a warning instead of attempting
   to parse \"175 cm\" or \"50 km/week\" — a parser would silently mis-convert
   garbage input.

3. **`elevation_per_mile` analysis column** stays imperial in the DB. The
   bilingual summary mitigates the LLM-context side. Activities table
   detail panel still shows \`ft/mi\` regardless of preference (one place,
   small follow-up).

## Test plan

- [x] `make test` — 389 passed (335 baseline + 54 new units & coach tests)
- [x] `npx tsc --noEmit` — clean
- [ ] `make dev` → toggle Settings → Imperial:
  - [ ] Activities table flips: distance to mi, pace to min/mi, speed to mph
        (cycling), elevation to ft, lifting volume to lb, per-set weights
        in detail panel to lb.
  - [ ] Calendar form labels flip; round-trip a workout (10 mi → save →
        reopen, value unchanged); switch to Metric → same workout reads
        as 16.09 km.
  - [ ] Charts: cardio weekly bar Y-axis flips mi ↔ km, ATL/CTL units flip;
        lifting volume bar flips kg ↔ lb, 1RM Y-axis flips. Legacy per-page
        Miles/km toggle is gone.
  - [ ] Chat: \"how was last week?\" — running response in min/mi, cycling
        response in mph, lifting response in lb. Re-toggle mid-conversation
        → next turn responds in new unit (re-seeded via \`init_backend\`).
- [ ] Existing user with \`localStorage[\"strides_unit\"] = \"miles\"\` and no
      DB \`units\` setting → first visit migrates to \`imperial\`, localStorage
      key removed, no UI flicker.
- [ ] New analysis output contains both unit forms (e.g. \`\"pace fade 18s/mi
      (11s/km)\"\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)