### PR TITLE
feat(coach): show all activity types to coach regardless of active mode

### DIFF
--- a/strides_ai/api/deps.py
+++ b/strides_ai/api/deps.py
@@ -96,7 +96,7 @@ def init_backend(app: FastAPI, mode: str | None = None, provider: str | None = N
     settings = get_settings()
     current_provider = (getattr(app.state, "provider", None) or settings.provider).lower()
 
-    activities = db.get_activities_for_mode(current_mode)
+    activities = db.get_all_activities()
     prior_messages = db.get_recent_messages(RECALL_MESSAGES, mode=current_mode)
     initial_history = build_initial_history(activities, prior_messages, mode=current_mode)
 

--- a/strides_ai/api/routers/chat.py
+++ b/strides_ai/api/routers/chat.py
@@ -89,7 +89,7 @@ async def chat(
     profile_fields = prof_crud.get_fields(session, mode)
     profile = profile_to_text(profile_fields, mode)
     coach_voice = (profile_fields or {}).get("coach_voice", "")
-    activities = [r.model_dump() for r in act_crud.get_for_mode(session, mode)]
+    activities = [r.model_dump() for r in act_crud.get_all(session)]
     system = build_system(
         profile,
         [r.model_dump() for r in memories],

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -137,6 +137,14 @@ def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
     if not rows:
         return "No activities found."
     cfg = MODES.get(mode, MODES["running"])
+
+    # When activities span multiple sport types, use the hybrid formatter
+    # (it has a TYPE column and handles mixed pace/speed/duration display).
+    if cfg.sport_types is not None:  # hybrid already uses its own formatter
+        types_present = {(r.get("sport_type") or "") for r in rows}
+        if not types_present.issubset(cfg.sport_types):
+            cfg = MODES["hybrid"]
+
     sep = "-" * cfg.log_sep_len
     lines = [cfg.log_header, sep]
     for r in reversed(rows):
@@ -158,7 +166,6 @@ def build_initial_history(
     history lives. It may be gracefully truncated by small-context models, but
     only the oldest runs are dropped — recent ones are protected by the system prompt.
     """
-    cfg = MODES.get(mode, MODES["running"])
     training_log = build_training_log(activities, mode)
     log_message = f"Here is the athlete's complete training log:\n\n```\n{training_log}\n```"
     return [
@@ -166,7 +173,7 @@ def build_initial_history(
         {
             "role": "assistant",
             "content": (
-                f"Got it — I have your full training log loaded ({len(activities)} {cfg.activity_label}). "
+                f"Got it — I have your full training log loaded ({len(activities)} activities). "
                 "What would you like to discuss?"
             ),
         },

--- a/strides_ai/modes.py
+++ b/strides_ai/modes.py
@@ -35,6 +35,10 @@ key metrics (distance, pace, HR).
 preferred snacks in their profile, choose from those; otherwise use sensible \
 defaults based on run distance and intensity.
 
+- The training log includes **all** of the athlete's activities (runs, walks, rides, \
+strength sessions, etc.) so you can assess total training load, cross-training, \
+and recovery. Your coaching focus and advice remains on running.
+
 The athlete's complete training log is included below. Treat it as ground \
 truth for all data-related questions.
 
@@ -58,6 +62,10 @@ key metrics (distance, speed, HR).
 (e.g. "2 gels, 1 energy bar, 750 ml electrolytes"). If the athlete has listed \
 preferred snacks in their profile, choose from those; otherwise use sensible \
 defaults based on ride duration and intensity.
+
+- The training log includes **all** of the athlete's activities (rides, runs, walks, \
+strength sessions, etc.) so you can assess total training load and recovery. \
+Your coaching focus and advice remains on cycling.
 
 The athlete's complete training log is included below. Treat it as ground \
 truth for all data-related questions.
@@ -104,6 +112,10 @@ key metrics (exercises, volume, RPE, estimated 1RM).
 - Use metric units (kg) unless the athlete asks otherwise.
 - When estimating 1-rep maxes, use the Epley formula (weight × (1 + reps/30)) and \
 note it is an estimate.
+
+- The training log includes **all** of the athlete's activities (strength sessions, \
+runs, walks, rides, etc.) so you can assess total training load and recovery. \
+Your coaching focus and advice remains on strength training.
 
 The athlete's complete training log is included below. Treat it as ground \
 truth for all data-related questions.

--- a/strides_ai/sync.py
+++ b/strides_ai/sync.py
@@ -1,4 +1,4 @@
-"""Fetch runs and rides from Strava and persist them locally."""
+"""Fetch all activities from Strava and persist them locally."""
 
 import logging
 from typing import Generator
@@ -7,10 +7,9 @@ import httpx
 
 from . import db
 from .analysis import RateLimitError, analyze_activity
-from .db import get_stored_ids, upsert_activity, RUN_TYPES, CYCLE_TYPES
+from .db import get_stored_ids, upsert_activity
 
 ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"
-ALL_SYNCED_TYPES = RUN_TYPES | CYCLE_TYPES
 PAGE_SIZE = 100
 
 log = logging.getLogger(__name__)
@@ -39,7 +38,7 @@ def _iter_activities(access_token: str) -> Generator[dict, None, None]:
 
 def sync_activities(access_token: str, full: bool = False) -> int:
     """
-    Sync run and cycling activities from Strava.
+    Sync all activities from Strava.
 
     If *full* is False (default), stops as soon as it encounters an activity
     already in the database — fast incremental sync.
@@ -55,10 +54,6 @@ def sync_activities(access_token: str, full: bool = False) -> int:
     rate_limited = False
 
     for activity in _iter_activities(access_token):
-        sport = activity.get("sport_type") or activity.get("type", "")
-        if sport not in ALL_SYNCED_TYPES:
-            continue
-
         if not full and activity["id"] in stored_ids:
             # In incremental mode, once we hit a known activity we're up-to-date
             break

--- a/tests/test_coach.py
+++ b/tests/test_coach.py
@@ -235,7 +235,7 @@ def test_build_initial_history_empty_activities():
 def test_build_initial_history_activity_count_in_reply():
     rows = [_make_row(), _make_row()]
     history = build_initial_history(rows, [])
-    assert "2 runs" in history[1]["content"]
+    assert "2 activities" in history[1]["content"]
 
 
 def test_build_initial_history_includes_prior_messages():
@@ -251,7 +251,7 @@ def test_build_initial_history_includes_prior_messages():
 
 def test_build_initial_history_cycling_label():
     history = build_initial_history([_make_row(sport_type="Ride")], [], mode="cycling")
-    assert "rides" in history[1]["content"]
+    assert "activities" in history[1]["content"]
 
 
 def test_build_initial_history_hybrid_label():


### PR DESCRIPTION
## Summary
- **Sync**: Removed the `ALL_SYNCED_TYPES` filter from `sync.py` so all Strava activity types (walks, hikes, yoga, etc.) are now persisted — not just runs and rides
- **Coach data feed**: Both the initial history seed (`deps.py`) and the per-turn system prompt (`chat.py`) now use `get_all_activities()` / `get_all()` instead of the mode-filtered query, so the coach sees the athlete's complete picture regardless of active mode
- **Training log format**: `build_training_log()` in `coach.py` auto-detects when activities span multiple sport types and switches to the hybrid formatter (which has a TYPE column and handles mixed pace/speed/duration display correctly)
- **System prompts**: Running, cycling, and lifting prompts now explicitly tell the coach the log includes all activity types, so it can reason about cross-training, recovery walks, and total load
- **Charts and activities list UI are unaffected** — both still call `get_for_mode()` directly and remain mode-filtered

## Motivation
The coach was blind to recovery walks, cross-training rides, strength sessions, etc. when in a mode-specific view. A running coach needs to see a recovery walk or a PT session to give accurate load and recovery advice. The mode should only determine coaching style and advice focus — not which data the coach can access.

## Test plan
- [x] `make test` passes (335 tests, pre-commit hook already verified)
- [ ] Trigger a **full sync** after deploying to backfill historical activities that were previously filtered out (walks, hikes, etc.)
- [ ] In running mode, ask the coach "What have I been doing lately?" and verify it references non-run activities
- [ ] Confirm charts still show only mode-appropriate data (e.g. running distances in running mode)
- [ ] Confirm activities list still shows mode-filtered activities in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)