### PR TITLE
feat(lifting): surface per-set RPE in coach context and add kg/lbs unit toggle

### DIFF
--- a/alembic/versions/007_avg_rpe.py
+++ b/alembic/versions/007_avg_rpe.py
@@ -1,0 +1,24 @@
+"""Add avg_rpe column to activities.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-05-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.add_column(sa.Column("avg_rpe", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.drop_column("avg_rpe")

--- a/strides_ai/api/app.py
+++ b/strides_ai/api/app.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .. import db
 from ..config import UPLOADS_DIR, get_settings
+from ..hevy_analysis import backfill_avg_rpe
 from ..modes import MODES
 from .deps import init_backend
 from .routers import (
@@ -29,6 +30,7 @@ from .routers import (
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+    backfill_avg_rpe()
     saved_mode = db.get_setting("mode", "running")
     saved_provider = db.get_setting("provider", get_settings().provider)
     init_backend(app, mode=saved_mode, provider=saved_provider)

--- a/strides_ai/api/deps.py
+++ b/strides_ai/api/deps.py
@@ -98,7 +98,11 @@ def init_backend(app: FastAPI, mode: str | None = None, provider: str | None = N
 
     activities = db.get_activities_for_mode(current_mode)
     prior_messages = db.get_recent_messages(RECALL_MESSAGES, mode=current_mode)
-    initial_history = build_initial_history(activities, prior_messages, mode=current_mode)
+    profile_fields = db.get_profile_fields(current_mode) or {}
+    weight_unit = profile_fields.get("weight_unit", "kg")
+    initial_history = build_initial_history(
+        activities, prior_messages, mode=current_mode, weight_unit=weight_unit
+    )
 
     if current_provider == "ollama":
         available = get_provider_models("ollama")

--- a/strides_ai/api/routers/chat.py
+++ b/strides_ai/api/routers/chat.py
@@ -89,6 +89,7 @@ async def chat(
     profile_fields = prof_crud.get_fields(session, mode)
     profile = profile_to_text(profile_fields, mode)
     coach_voice = (profile_fields or {}).get("coach_voice", "")
+    weight_unit = (profile_fields or {}).get("weight_unit", "kg")
     activities = [r.model_dump() for r in act_crud.get_for_mode(session, mode)]
     system = build_system(
         profile,
@@ -96,6 +97,7 @@ async def chat(
         mode=mode,
         activities=activities,
         coach_voice=coach_voice,
+        weight_unit=weight_unit,
     )
 
     conv_crud.save(session, "user", saved_message, mode=mode)

--- a/strides_ai/coach.py
+++ b/strides_ai/coach.py
@@ -58,6 +58,7 @@ def build_system(
     mode: str = "running",
     activities: list | None = None,
     coach_voice: str = "",
+    weight_unit: str = "kg",
 ) -> str:
     cfg = MODES.get(mode, MODES["running"])
     prompt = cfg.system_prompt
@@ -125,29 +126,116 @@ def build_system(
             "positive = slowing (possible fatigue), negative = negative split"
         )
 
-    recent_log = build_training_log(recent, mode)
+    recent_log = build_training_log(recent, mode, weight_unit=weight_unit)
     prompt += (
         f"\n\n## Recent Activities (last {RECENT_ACTIVITIES_IN_SYSTEM})\n\n```\n{recent_log}\n```"
     )
 
+    if mode == "lifting" or (
+        mode == "hybrid" and any(a.get("sport_type") == "WeightTraining" for a in recent)
+    ):
+        detail = build_lifting_detail(recent, weight_unit=weight_unit)
+        if detail:
+            prompt += (
+                f"\n\n## Lifting Session Detail (last {LIFTING_DETAIL_SESSIONS} sessions)\n\n"
+                "Per-set breakdown. Use this to reason about RPE trends, rep ranges, and progression.\n\n"
+                f"{detail}"
+            )
+
     return prompt
 
 
-def build_training_log(rows: list[sqlite3.Row], mode: str = "running") -> str:
+LIFTING_DETAIL_SESSIONS = 10
+
+
+_KG_TO_LBS = 2.20462
+
+
+def build_lifting_detail(activities: list[dict], weight_unit: str = "kg") -> str:
+    """Compact per-set breakdown for recent lifting sessions."""
+    import json
+
+    use_lbs = weight_unit == "lbs"
+
+    lifting_acts = [
+        a for a in activities if a.get("sport_type") == "WeightTraining" and a.get("exercises_json")
+    ][:LIFTING_DETAIL_SESSIONS]
+
+    if not lifting_acts:
+        return ""
+
+    blocks: list[str] = []
+    for act in lifting_acts:
+        date_str = act.get("date") or "?"
+        name = act.get("name") or "Weight Training"
+        avg_rpe = act.get("avg_rpe")
+        rpe_label = f"  avg RPE {avg_rpe}" if avg_rpe is not None else ""
+        blocks.append(f"### {date_str} — {name}{rpe_label}")
+
+        try:
+            exercises = json.loads(act["exercises_json"])
+        except (json.JSONDecodeError, TypeError):
+            blocks.append("  (exercise data unavailable)")
+            continue
+
+        for ex in exercises:
+            title = ex.get("title") or "Unknown"
+            muscle = ex.get("primary_muscle_group") or ""
+            muscle_suffix = f" [{muscle}]" if muscle else ""
+            blocks.append(f"  {title}{muscle_suffix}")
+
+            for s in ex.get("sets", []):
+                set_type = s.get("type", "normal")
+                if set_type == "warmup":
+                    prefix = "[W] "
+                elif set_type == "normal":
+                    prefix = "    "
+                else:
+                    prefix = f"[{set_type}] "
+
+                weight_kg = s.get("weight_kg")
+                if weight_kg:
+                    if use_lbs:
+                        weight_str = f"{round(weight_kg * _KG_TO_LBS, 1)} lbs"
+                    else:
+                        weight_str = f"{weight_kg} kg"
+                else:
+                    weight_str = "BW"
+                reps = s.get("reps")
+                reps_str = f"x{reps}" if reps is not None else "x?"
+                rpe = s.get("rpe")
+                rpe_str = f"  RPE {rpe}" if rpe is not None else ""
+
+                blocks.append(f"  {prefix}{weight_str} {reps_str}{rpe_str}")
+
+        blocks.append("")
+
+    return "\n".join(blocks)
+
+
+def build_training_log(
+    rows: list[sqlite3.Row], mode: str = "running", weight_unit: str = "kg"
+) -> str:
     if not rows:
         return "No activities found."
     cfg = MODES.get(mode, MODES["running"])
     sep = "-" * cfg.log_sep_len
-    lines = [cfg.log_header, sep]
-    for r in reversed(rows):
+    header = cfg.log_header
+    formatted_rows = rows
+    if mode == "lifting":
+        if weight_unit == "lbs":
+            header = header.replace("VOLUME(kg)", "VOLUME(lbs)")
+        formatted_rows = [{**r, "_weight_unit": weight_unit} for r in rows]
+    lines = [header, sep]
+    for r in reversed(formatted_rows):
         lines.append(cfg.format_log_row(r))
     lines.append(sep)
-    lines.append(cfg.format_log_total(rows))
+    lines.append(cfg.format_log_total(formatted_rows))
     return "\n".join(lines)
 
 
 def build_initial_history(
-    activities: list, prior_messages: list[dict], mode: str = "running"
+    activities: list, prior_messages: list[dict], mode: str = "running", weight_unit: str = "kg"
 ) -> list[dict]:
     """
     Seed the backend's conversation history with the full training log (once)
@@ -159,7 +247,7 @@ def build_initial_history(
     only the oldest runs are dropped — recent ones are protected by the system prompt.
     """
     cfg = MODES.get(mode, MODES["running"])
-    training_log = build_training_log(activities, mode)
+    training_log = build_training_log(activities, mode, weight_unit=weight_unit)
     log_message = f"Here is the athlete's complete training log:\n\n```\n{training_log}\n```"
     return [
         {"role": "user", "content": log_message},

--- a/strides_ai/db/models.py
+++ b/strides_ai/db/models.py
@@ -56,6 +56,7 @@ class Activity(SQLModel, table=True):
     exercises_json: Optional[str] = None
     total_volume_kg: Optional[float] = None
     total_sets: Optional[int] = None
+    avg_rpe: Optional[float] = None
 
 
 class Conversation(SQLModel, table=True):

--- a/strides_ai/hevy_analysis.py
+++ b/strides_ai/hevy_analysis.py
@@ -140,10 +140,32 @@ def analyze_hevy_workout(row: dict) -> None:
         {
             "total_volume_kg": metrics["total_volume_kg"],
             "total_sets": metrics["total_sets"],
+            "avg_rpe": metrics["avg_rpe"],
             "analysis_summary": metrics["analysis_summary"],
             "analysis_status": "done",
         },
     )
+
+
+def backfill_avg_rpe() -> int:
+    """Compute and store avg_rpe for existing WeightTraining rows that have exercises_json but no avg_rpe."""
+    from . import db
+
+    count = 0
+    for act in db.get_all_activities():
+        if act.get("sport_type") != "WeightTraining":
+            continue
+        if act.get("avg_rpe") is not None:
+            continue
+        if not act.get("exercises_json"):
+            continue
+        metrics = compute_hevy_metrics(act["exercises_json"])
+        if not metrics or metrics.get("avg_rpe") is None:
+            continue
+        db.save_analysis(act["id"], {"avg_rpe": metrics["avg_rpe"]})
+        count += 1
+    log.info("backfill_avg_rpe: updated %d activities", count)
+    return count
 
 
 LIFTING_DEEP_DIVE_SYSTEM_PROMPT = """\

--- a/strides_ai/modes.py
+++ b/strides_ai/modes.py
@@ -208,15 +208,25 @@ def _hybrid_log_row(r: dict) -> str:
     )
 
 
+_KG_TO_LBS = 2.20462
+
+
 def _lifting_log_row(r: dict) -> str:
     analysis = (r.get("analysis_summary") or "")[:60]
+    use_lbs = r.get("_weight_unit") == "lbs"
+    raw_volume = r.get("total_volume_kg") or 0
+    if raw_volume:
+        volume = round(raw_volume * _KG_TO_LBS) if use_lbs else round(raw_volume)
+        volume_str = str(volume)
+    else:
+        volume_str = "—"
     return (
         f"{r['date'] or '?':10s} | "
         f"{(r['name'] or '')[:30]:30s} | "
         f"{_format_duration(r['moving_time_s']):8s} | "
         f"{r['total_sets'] or '—':4} | "
-        f"{r['total_volume_kg'] or '—':10} | "
-        f"{r['perceived_exertion'] or '—':3} | "
+        f"{volume_str:10} | "
+        f"{r.get('avg_rpe') or '—':3} | "
         f"{analysis}"
     )
 
@@ -230,7 +240,11 @@ def _make_cardio_total(label: str) -> Callable[[list[dict]], str]:
 
 
 def _lifting_log_total(rows: list[dict]) -> str:
-    total_volume = sum((r["total_volume_kg"] or 0) for r in rows)
+    use_lbs = rows[0].get("_weight_unit") == "lbs" if rows else False
+    total_volume = sum((r.get("total_volume_kg") or 0) for r in rows)
+    if use_lbs:
+        total_volume = total_volume * _KG_TO_LBS
+        return f"Total: {len(rows)} sessions, {total_volume:.0f} lbs cumulative volume"
     return f"Total: {len(rows)} sessions, {total_volume:.0f} kg cumulative volume"
 
 

--- a/strides_ai/profile.py
+++ b/strides_ai/profile.py
@@ -130,6 +130,7 @@ LIFTING_DEFAULTS: dict = {
     "nutrition_snacks": [],
     "other_notes": "",
     "coach_voice": "",
+    "weight_unit": "kg",
 }
 
 _DEFAULTS = {

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -73,6 +73,7 @@ def test_get_default_fields_lifting_keys():
         "nutrition_snacks",
         "other_notes",
         "coach_voice",
+        "weight_unit",
     }
 
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -94,6 +94,7 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
   const [customText, setCustomText] = useState<Record<string, string>>({});
   const [customSelected, setCustomSelected] = useState<Record<string, boolean>>({});
   const [voiceSaving, setVoiceSaving] = useState(false);
+  const [weightUnit, setWeightUnit] = useState<"kg" | "lbs">("kg");
 
   useEffect(() => {
     const modes: Mode[] = ["running", "cycling", "hybrid", "lifting"];
@@ -111,6 +112,15 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
       setCustomSelected(Object.fromEntries(customEntries.map(([m]) => [m, true])));
     });
   }, []);
+
+  useEffect(() => {
+    if (mode === "lifting") {
+      fetch(`/api/profile?mode=lifting`)
+        .then((r) => r.json())
+        .then(({ fields }) => setWeightUnit((fields?.weight_unit as "kg" | "lbs") || "kg"))
+        .catch(() => {});
+    }
+  }, [mode]);
 
   useEffect(() => {
     fetch("/api/providers")
@@ -145,6 +155,16 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
     } finally {
       setVoiceSaving(false);
     }
+  }
+
+  async function handleWeightUnitChange(unit: "kg" | "lbs") {
+    setWeightUnit(unit);
+    const { fields } = await fetch(`/api/profile?mode=lifting`).then((r) => r.json());
+    await fetch(`/api/profile?mode=lifting`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fields: { ...fields, weight_unit: unit } }),
+    });
   }
 
   async function handleModeChange(newMode: Mode) {
@@ -331,6 +351,32 @@ export default function Settings({ mode, setMode, theme, onProviderChanged }: Pr
               );
             })()}
           </section>
+
+          {mode === "lifting" && (
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+                Weight Unit
+              </h3>
+              <p className="text-xs text-gray-600 mb-3">
+                Unit used when the coach references weights in feedback and session breakdowns.
+              </p>
+              <div className="flex gap-2">
+                {(["kg", "lbs"] as const).map((u) => (
+                  <button
+                    key={u}
+                    onClick={() => handleWeightUnitChange(u)}
+                    className={`px-4 py-1.5 rounded text-xs font-medium border transition-colors ${
+                      weightUnit === u
+                        ? "bg-orange-500 border-orange-500 text-white"
+                        : "bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-500"
+                    }`}
+                  >
+                    {u}
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
 
           <section>
             <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">


### PR DESCRIPTION
## Summary

- **avg_rpe per session**: Computes average RPE from Hevy set data and stores it in a new `avg_rpe` column (Alembic migration 007). Existing sessions are backfilled at startup.
- **Coach context**: Injects a per-set weight/RPE breakdown for the last 10 lifting sessions into the system prompt, giving the coach visibility into rep ranges, RPE trends, and progression.
- **kg/lbs toggle**: Adds a `weight_unit` profile field (default `kg`) for the lifting mode. A new Settings toggle persists the preference; all coach output (training log, lifting detail, totals) respects it.

## Test plan

- [ ] Sync Hevy workouts and confirm `avg_rpe` is populated in new and backfilled sessions
- [ ] Toggle weight unit in Settings (lifting mode) and verify the coach log and detail section show the correct unit
- [ ] Confirm the per-set breakdown appears in the system prompt for lifting/hybrid modes
- [ ] Verify migration 007 runs cleanly on a fresh DB and on an existing DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)